### PR TITLE
Do skewed join and adaptive partition only when all leaf nodes are shuffles

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala
@@ -97,6 +97,7 @@ abstract class QueryStage extends UnaryExecNode {
     // It is possible to optimize this stage's plan here based on the child stages' statistics.
     val oldChild = child
     OptimizeJoin(conf).apply(this)
+    HandleSkewedJoin(conf).apply(this)
     // If the Joins are changed, we need apply EnsureRequirements rule to add BroadcastExchange.
     if (!oldChild.fastEquals(child)) {
       child = EnsureRequirements(conf).apply(child)
@@ -106,32 +107,34 @@ abstract class QueryStage extends UnaryExecNode {
     val queryStageInputs: Seq[ShuffleQueryStageInput] = child.collect {
       case input: ShuffleQueryStageInput if !input.isLocalShuffle => input
     }
-    val numOfLeafNodes = child.collect{case n: LeafExecNode => n}.length
-    if (queryStageInputs.length == numOfLeafNodes) {
-      HandleSkewedJoin(conf).apply(this)
-      val childMapOutputStatistics = queryStageInputs.map(_.childStage.mapOutputStatistics)
-        .filter(_ != null).toArray
-      if (childMapOutputStatistics.length > 0) {
-        val exchangeCoordinator = new ExchangeCoordinator(
-          conf.targetPostShuffleInputSize,
-          conf.adaptiveTargetPostShuffleRowCount,
-          conf.minNumPostShufflePartitions)
+    val childMapOutputStatistics = queryStageInputs.map(_.childStage.mapOutputStatistics)
+      .filter(_ != null).toArray
+    val numOfAELeafNodes = child.collect { case n: LeafExecNode => n }
+      .count {
+        case _: SkewedShuffleQueryStageInput => false
+        case input: ShuffleQueryStageInput if input.isLocalShuffle => false
+        case _ => true
+      }
+    if (childMapOutputStatistics.length > 0 && queryStageInputs.length == numOfAELeafNodes) {
+      val exchangeCoordinator = new ExchangeCoordinator(
+        conf.targetPostShuffleInputSize,
+        conf.adaptiveTargetPostShuffleRowCount,
+        conf.minNumPostShufflePartitions)
 
-        if (queryStageInputs.length == 2 && queryStageInputs.forall(_.skewedPartitions.isDefined)) {
-          // If a skewed join is detected and optimized, we will omit the skewed partitions when
-          // estimate the partition start and end indices.
-          val (partitionStartIndices, partitionEndIndices) =
+      if (queryStageInputs.length == 2 && queryStageInputs.forall(_.skewedPartitions.isDefined)) {
+        // If a skewed join is detected and optimized, we will omit the skewed partitions when
+        // estimate the partition start and end indices.
+        val (partitionStartIndices, partitionEndIndices) =
           exchangeCoordinator.estimatePartitionStartEndIndices(
             childMapOutputStatistics, queryStageInputs(0).skewedPartitions.get)
-          queryStageInputs.foreach { i =>
-            i.partitionStartIndices = Some(partitionStartIndices)
-            i.partitionEndIndices = Some(partitionEndIndices)
-          }
-        } else {
-          val partitionStartIndices =
-            exchangeCoordinator.estimatePartitionStartIndices(childMapOutputStatistics)
-          queryStageInputs.foreach(_.partitionStartIndices = Some(partitionStartIndices))
+        queryStageInputs.foreach { i =>
+          i.partitionStartIndices = Some(partitionStartIndices)
+          i.partitionEndIndices = Some(partitionEndIndices)
         }
+      } else {
+        val partitionStartIndices =
+          exchangeCoordinator.estimatePartitionStartIndices(childMapOutputStatistics)
+        queryStageInputs.foreach(_.partitionStartIndices = Some(partitionStartIndices))
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Do skewed join and adaptive partition only when all leaf nodes are shuffles.
Otherwise, AE fails in the scenario like bucket join.

![image](https://user-images.githubusercontent.com/2989575/40869224-9d2746f6-6649-11e8-8af8-bbe0ffe0dfef.png)

## How was this patch tested?

Unit tests and manually tests.
