### PR TITLE
Refactor statsEstimation/Statistics

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputStatistics.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputStatistics.scala
@@ -27,5 +27,5 @@ package org.apache.spark
 private[spark] class MapOutputStatistics(
     val shuffleId: Int,
     val bytesByPartitionId: Array[Long],
-    val recordsByPartitionId: Array[Long] = Array[Long]())
+    val rowCountsByPartitionId: Array[Long] = Array[Long]())
   extends Serializable

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/LocalTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/LocalTableScanExec.scala
@@ -78,6 +78,6 @@ case class LocalTableScanExec(
   override def computeStats(): Statistics = {
     val rowSize = 8 + output.map(_.dataType.defaultSize).sum
     val rowCount = rows.size
-    Statistics(rowSize * rowCount)
+    Statistics(sizeInBytes = rowSize * rowCount, rowCount = Some(rowCount))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/HandleSkewedJoin.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/HandleSkewedJoin.scala
@@ -51,14 +51,14 @@ case class HandleSkewedJoin(conf: SQLConf) extends Rule[SparkPlan] {
       medianSize: Long,
       medianRowCount: Long): Boolean = {
     isSizeSkewed(stats.bytesByPartitionId(partitionId), medianSize) ||
-      isRowCountSkewed(stats.recordsByPartitionId(partitionId), medianRowCount)
+      isRowCountSkewed(stats.rowCountsByPartitionId(partitionId), medianRowCount)
   }
 
   private def medianSizeAndRowCount(stats: PartitionStatistics): (Long, Long) = {
     val bytesLen = stats.bytesByPartitionId.length
-    val rowCountsLen = stats.recordsByPartitionId.length
+    val rowCountsLen = stats.rowCountsByPartitionId.length
     val bytes = stats.bytesByPartitionId.sorted
-    val rowCounts = stats.recordsByPartitionId.sorted
+    val rowCounts = stats.rowCountsByPartitionId.sorted
     val medSize = if (bytes(bytesLen / 2) > 0) bytes(bytesLen / 2) else 1
     val medRowCount = if (rowCounts(rowCountsLen / 2) > 0) rowCounts(rowCountsLen / 2) else 1
     (medSize, medRowCount)
@@ -89,7 +89,7 @@ case class HandleSkewedJoin(conf: SQLConf) extends Rule[SparkPlan] {
       medianRowCount: Long): Array[Int] = {
     val stats = queryStageInput.childStage.stats
     val size = stats.bytesByPartitionId.get(partitionId)
-    val rowCount = stats.recordStatistics.get.recordsByPartitionId(partitionId)
+    val rowCount = stats.rowCountsByPartitionId.get(partitionId)
     val factor = Math.max(size / medianSize, rowCount / medianRowCount)
     val numSplits = Math.min(conf.adaptiveSkewedMaxSplits,
       Math.min(factor.toInt, queryStageInput.numMapper))
@@ -122,9 +122,9 @@ case class HandleSkewedJoin(conf: SQLConf) extends Rule[SparkPlan] {
         s" right medSize/rowCounts ($rightMedSize, $rightMedRowCount)")
 
       logInfo(s"left bytes Max : ${leftStats.bytesByPartitionId.max}")
-      logInfo(s"left row counts Max : ${leftStats.recordsByPartitionId.max}")
+      logInfo(s"left row counts Max : ${leftStats.rowCountsByPartitionId.max}")
       logInfo(s"right bytes Max : ${rightStats.bytesByPartitionId.max}")
-      logInfo(s"right row counts Max : ${rightStats.recordsByPartitionId.max}")
+      logInfo(s"right row counts Max : ${rightStats.rowCountsByPartitionId.max}")
 
       val skewedPartitions = mutable.HashSet[Int]()
       val subJoins = mutable.ArrayBuffer[SparkPlan](smj)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala
@@ -543,7 +543,7 @@ case class RangeExec(range: org.apache.spark.sql.catalyst.plans.logical.Range)
   override def simpleString: String = s"Range ($start, $end, step=$step, splits=$numSlices)"
 
   override def computeStats: Statistics = {
-    Statistics(LongType.defaultSize * numElements)
+    Statistics(sizeInBytes = LongType.defaultSize * numElements, rowCount = Some(numElements))
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/columnar/InMemoryTableScanExec.scala
@@ -286,6 +286,6 @@ case class InMemoryTableScanExec(
 
   override def computeStats(): Statistics = {
     val stats = relation.computeStats()
-    Statistics(stats.sizeInBytes)
+    Statistics(sizeInBytes = stats.sizeInBytes, rowCount = stats.rowCount)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
@@ -134,8 +134,8 @@ class ExchangeCoordinator(
       while (j < mapOutputStatistics.length) {
         val statistics = mapOutputStatistics(j)
         size += statistics.bytesByPartitionId(partitionId)
-        if (statistics.recordsByPartitionId.nonEmpty) {
-          rowCount += statistics.recordsByPartitionId(partitionId)
+        if (statistics.rowCountsByPartitionId.nonEmpty) {
+          rowCount += statistics.rowCountsByPartitionId(partitionId)
         }
         j += 1
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
@@ -75,12 +75,13 @@ object SizeInBytesOnlyStatsPlanVisitor extends SparkPlanVisitor[Statistics] {
     if (p.mapOutputStatistics != null) {
       val sizeInBytes = p.mapOutputStatistics.bytesByPartitionId.sum
       val bytesByPartitionId = p.mapOutputStatistics.bytesByPartitionId
-      if (p.mapOutputStatistics.recordsByPartitionId.nonEmpty) {
-        val record = p.mapOutputStatistics.recordsByPartitionId.sum
-        val recordsByPartitionId = p.mapOutputStatistics.recordsByPartitionId
+      if (p.mapOutputStatistics.rowCountsByPartitionId.nonEmpty) {
+        val rowCount = p.mapOutputStatistics.rowCountsByPartitionId.sum
+        val rowCountsByPartitionId = p.mapOutputStatistics.rowCountsByPartitionId
         Statistics(sizeInBytes = sizeInBytes,
+          rowCount = Some(rowCount),
           bytesByPartitionId = Some(bytesByPartitionId),
-          recordStatistics = Some(RecordStatistics(record, recordsByPartitionId)))
+          rowCountsByPartitionId = Some(rowCountsByPartitionId))
       } else {
         Statistics(sizeInBytes = sizeInBytes, bytesByPartitionId = Some(bytesByPartitionId))
       }
@@ -112,12 +113,13 @@ object SizeInBytesOnlyStatsPlanVisitor extends SparkPlanVisitor[Statistics] {
     if (p.mapOutputStatistics != null) {
       val sizeInBytes = p.mapOutputStatistics.bytesByPartitionId.sum
       val bytesByPartitionId = p.mapOutputStatistics.bytesByPartitionId
-      if (p.mapOutputStatistics.recordsByPartitionId.nonEmpty) {
-        val record = p.mapOutputStatistics.recordsByPartitionId.sum
-        val recordsByPartitionId = p.mapOutputStatistics.recordsByPartitionId
+      if (p.mapOutputStatistics.rowCountsByPartitionId.nonEmpty) {
+        val rowCount = p.mapOutputStatistics.rowCountsByPartitionId.sum
+        val rowCountsByPartitionId = p.mapOutputStatistics.rowCountsByPartitionId
         Statistics(sizeInBytes = sizeInBytes,
+          rowCount = Some(rowCount),
           bytesByPartitionId = Some(bytesByPartitionId),
-          recordStatistics = Some(RecordStatistics(record, recordsByPartitionId)))
+          rowCountsByPartitionId = Some(rowCountsByPartitionId))
       } else {
         Statistics(sizeInBytes = sizeInBytes, bytesByPartitionId = Some(bytesByPartitionId))
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/statsEstimation/Statistics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/statsEstimation/Statistics.scala
@@ -41,25 +41,22 @@ import org.apache.spark.util.Utils
 
 case class PartitionStatistics(
     bytesByPartitionId: Array[Long],
-    recordsByPartitionId: Array[Long])
-
-case class RecordStatistics(
-    record: BigInt,
-    recordsByPartitionId: Array[Long])
+    rowCountsByPartitionId: Array[Long])
 
 case class Statistics(
     sizeInBytes: BigInt,
+    rowCount: Option[BigInt] = None,
     bytesByPartitionId: Option[Array[Long]] = None,
-    recordStatistics: Option[RecordStatistics] = None) {
+    rowCountsByPartitionId: Option[Array[Long]] = None) {
 
   override def toString: String = "Statistics(" + simpleString + ")"
 
   /** Readable string representation for the Statistics. */
   def simpleString: String = {
     Seq(s"sizeInBytes=${Utils.bytesToString(sizeInBytes)}",
-      if (recordStatistics.isDefined) {
+      if (rowCount.isDefined) {
         // Show row count in scientific notation.
-        s"record=${BigDecimal(recordStatistics.get.record,
+        s"rowCount=${BigDecimal(rowCount.get,
           new MathContext(3, RoundingMode.HALF_UP)).toString()}"
       } else {
         ""
@@ -68,8 +65,8 @@ case class Statistics(
   }
 
   def getPartitionStatistics : Option[PartitionStatistics] = {
-    if (bytesByPartitionId.isDefined && recordStatistics.isDefined) {
-      Some(PartitionStatistics(bytesByPartitionId.get, recordStatistics.get.recordsByPartitionId))
+    if (bytesByPartitionId.isDefined && rowCountsByPartitionId.isDefined) {
+      Some(PartitionStatistics(bytesByPartitionId.get, rowCountsByPartitionId.get))
     } else {
       None
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/QueryStageSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/QueryStageSuite.scala
@@ -364,7 +364,7 @@ class QueryStageSuite extends SparkFunSuite with BeforeAndAfterAll {
       // MapStatus uses log base 1.1 on records to compress,
       // after decompressing, it becomes to 106
       val stats = siAfterExecution.head.childStage.mapOutputStatistics
-      assert(stats.recordsByPartitionId.count(_ == 106) == 1)
+      assert(stats.rowCountsByPartitionId.count(_ == 106) == 1)
     }
   }
 
@@ -390,7 +390,7 @@ class QueryStageSuite extends SparkFunSuite with BeforeAndAfterAll {
       // MapStatus uses log base 1.1 on records to compress,
       // after decompressing, it becomes to 106
       val stats = siAfterExecution.head.childStage.mapOutputStatistics
-      assert(stats.recordsByPartitionId.count(_ == 106) == 1)
+      assert(stats.rowCountsByPartitionId.count(_ == 106) == 1)
     }
   }
 
@@ -412,7 +412,7 @@ class QueryStageSuite extends SparkFunSuite with BeforeAndAfterAll {
       assert(siAfterExecution.length === 1)
 
       val stats = siAfterExecution.head.childStage.mapOutputStatistics
-      assert(stats.recordsByPartitionId.isEmpty)
+      assert(stats.rowCountsByPartitionId.isEmpty)
     }
   }
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
@@ -216,6 +216,6 @@ case class HiveTableScanExec(
 
   override def computeStats(): Statistics = {
     val stats = relation.computeStats()
-    Statistics(stats.sizeInBytes)
+    Statistics(sizeInBytes = stats.sizeInBytes, rowCount = stats.rowCount)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactor statsEstimation/Statistics.

Before:
```
 case class Statistics(
     sizeInBytes: BigInt,
     bytesByPartitionId: Option[Array[Long]] = None,
     recordStatistics: Option[RecordStatistics] = None) {
```
After:
```
case class Statistics(
    sizeInBytes: BigInt,
    rowCount: Option[BigInt] = None,
    bytesByPartitionId: Option[Array[Long]] = None,
    rowCountsByPartitionId: Option[Array[Long]] = None) {
```

## How was this patch tested?

unit tests.
