### PR TITLE
Show correct explain

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala
@@ -183,7 +183,7 @@ abstract class QueryStage extends UnaryExecNode {
       verbose: Boolean,
       prefix: String = "",
       addSuffix: Boolean = false): StringBuilder = {
-    child.generateTreeString(depth, lastChildren, builder, verbose, "*")
+    child.generateTreeString(depth, lastChildren, builder, verbose)
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala
@@ -69,7 +69,7 @@ abstract class QueryStageInput extends LeafExecNode {
       verbose: Boolean,
       prefix: String = "",
       addSuffix: Boolean = false): StringBuilder = {
-    childStage.generateTreeString(depth, lastChildren, builder, verbose, "*")
+    childStage.generateTreeString(depth, lastChildren, builder, verbose)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

'*' means this operator supports whole stage code gen.

Before:
```
== Physical Plan ==
*SortMergeJoin [ws_sold_date_sk#35], [d_date_sk#36], Inner
:- *Sort [ws_sold_date_sk#35 ASC NULLS FIRST], false, 0
:  +- *Exchange hashpartitioning(ws_sold_date_sk#35, 500)
:     +- *FileScan parquet tpcds10.web_sales[ws_sold_time_sk#2,ws_ship_date_sk#3,ws_item_sk#4,ws_bill_customer_sk#5,ws_bill_cdemo_sk#6,ws_bill_hdemo_sk#7,ws_bill_addr_sk#8,ws_ship_customer_sk#9,ws_ship_cdemo_sk#10,ws_ship_hdemo_sk#11,ws_ship_addr_sk#12,ws_web_page_sk#13,ws_web_site_sk#14,ws_ship_mode_sk#15,ws_warehouse_sk#16,ws_promo_sk#17,ws_order_number#18L,ws_quantity#19,ws_wholesale_cost#20,ws_list_price#21,ws_sales_price#22,ws_ext_discount_amt#23,ws_ext_sales_price#24,ws_ext_wholesale_cost#25,... 10 more fields] Batched: true, Format: Parquet, Location: PrunedInMemoryFileIndex[file:/Users/yyu1/work/datasets/tpcds10/web_sales/ws_sold_date_sk=2450816,..., PartitionCount: 1823, PartitionFilters: [isnotnull(ws_sold_date_sk#35)], PushedFilters: [], ReadSchema: struct<ws_sold_time_sk:int,ws_ship_date_sk:int,ws_item_sk:int,ws_bill_customer_sk:int,ws_bill_cde...
+- *Sort [d_date_sk#36 ASC NULLS FIRST], false, 0
   +- *Exchange hashpartitioning(d_date_sk#36, 500)
      +- *Project [d_date_sk#36, d_date_id#37, d_date#38, d_month_seq#39, d_week_seq#40, d_quarter_seq#41, d_year#42, d_dow#43, d_moy#44, d_dom#45, d_qoy#46, d_fy_year#47, d_fy_quarter_seq#48, d_fy_week_seq#49, d_day_name#50, d_quarter_name#51, d_holiday#52, d_weekend#53, d_following_holiday#54, d_first_dom#55, d_last_dom#56, d_same_day_ly#57, d_same_day_lq#58, d_current_day#59, ... 4 more fields]
         +- *Filter isnotnull(d_date_sk#36)
            +- *FileScan parquet tpcds10.date_dim[d_date_sk#36,d_date_id#37,d_date#38,d_month_seq#39,d_week_seq#40,d_quarter_seq#41,d_year#42,d_dow#43,d_moy#44,d_dom#45,d_qoy#46,d_fy_year#47,d_fy_quarter_seq#48,d_fy_week_seq#49,d_day_name#50,d_quarter_name#51,d_holiday#52,d_weekend#53,d_following_holiday#54,d_first_dom#55,d_last_dom#56,d_same_day_ly#57,d_same_day_lq#58,d_current_day#59,... 4 more fields] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/Users/yyu1/work/datasets/tpcds10/date_dim], PartitionFilters: [], PushedFilters: [IsNotNull(d_date_sk)], ReadSchema: struct<d_date_sk:int,d_date_id:string,d_date:date,d_month_seq:int,d_week_seq:int,d_quarter_seq:in...
```
After:
```
== Physical Plan ==
SortMergeJoin [ws_sold_date_sk#35], [d_date_sk#36], Inner
:- Sort [ws_sold_date_sk#35 ASC NULLS FIRST], false, 0
:  +- Exchange hashpartitioning(ws_sold_date_sk#35, 500)
:     +- FileScan parquet tpcds10.web_sales[ws_sold_time_sk#2,ws_ship_date_sk#3,ws_item_sk#4,ws_bill_customer_sk#5,ws_bill_cdemo_sk#6,ws_bill_hdemo_sk#7,ws_bill_addr_sk#8,ws_ship_customer_sk#9,ws_ship_cdemo_sk#10,ws_ship_hdemo_sk#11,ws_ship_addr_sk#12,ws_web_page_sk#13,ws_web_site_sk#14,ws_ship_mode_sk#15,ws_warehouse_sk#16,ws_promo_sk#17,ws_order_number#18L,ws_quantity#19,ws_wholesale_cost#20,ws_list_price#21,ws_sales_price#22,ws_ext_discount_amt#23,ws_ext_sales_price#24,ws_ext_wholesale_cost#25,... 10 more fields] Batched: true, Format: Parquet, Location: PrunedInMemoryFileIndex[file:/Users/yyu1/work/datasets/tpcds10/web_sales/ws_sold_date_sk=2450816,..., PartitionCount: 1823, PartitionFilters: [isnotnull(ws_sold_date_sk#35)], PushedFilters: [], ReadSchema: struct<ws_sold_time_sk:int,ws_ship_date_sk:int,ws_item_sk:int,ws_bill_customer_sk:int,ws_bill_cde...
+- Sort [d_date_sk#36 ASC NULLS FIRST], false, 0
   +- Exchange hashpartitioning(d_date_sk#36, 500)
      +- Project [d_date_sk#36, d_date_id#37, d_date#38, d_month_seq#39, d_week_seq#40, d_quarter_seq#41, d_year#42, d_dow#43, d_moy#44, d_dom#45, d_qoy#46, d_fy_year#47, d_fy_quarter_seq#48, d_fy_week_seq#49, d_day_name#50, d_quarter_name#51, d_holiday#52, d_weekend#53, d_following_holiday#54, d_first_dom#55, d_last_dom#56, d_same_day_ly#57, d_same_day_lq#58, d_current_day#59, ... 4 more fields]
         +- Filter isnotnull(d_date_sk#36)
            +- FileScan parquet tpcds10.date_dim[d_date_sk#36,d_date_id#37,d_date#38,d_month_seq#39,d_week_seq#40,d_quarter_seq#41,d_year#42,d_dow#43,d_moy#44,d_dom#45,d_qoy#46,d_fy_year#47,d_fy_quarter_seq#48,d_fy_week_seq#49,d_day_name#50,d_quarter_name#51,d_holiday#52,d_weekend#53,d_following_holiday#54,d_first_dom#55,d_last_dom#56,d_same_day_ly#57,d_same_day_lq#58,d_current_day#59,... 4 more fields] Batched: true, Format: Parquet, Location: InMemoryFileIndex[file:/Users/yyu1/work/datasets/tpcds10/date_dim], PartitionFilters: [], PushedFilters: [IsNotNull(d_date_sk)], ReadSchema: struct<d_date_sk:int,d_date_id:string,d_date:date,d_month_seq:int,d_week_seq:int,d_quarter_seq:in...
```

## How was this patch tested?

Manually check.