### PR TITLE
auto calculate the initial partition number with ae

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -304,7 +304,7 @@ object SQLConf {
         "must be a positive integer.")
       .createWithDefault(500)
 
-  val ADAPTIVE_EXECUTION_AUTOCALCULATEINITIALPARTITIONNUM =
+  val ADAPTIVE_EXECUTION_AUTO_CALCULATE_INITIAL_PARTITION_NUM =
     buildConf("spark.sql.adaptive.autoCalculateInitialPartitionNum")
       .doc("When true and adaptive execution is enabled," +
         " spark will calculate the initial partition number" +
@@ -1374,7 +1374,7 @@ class SQLConf extends Serializable with Logging {
   def maxNumPostShufflePartitions: Int = getConf(SHUFFLE_MAX_NUM_POSTSHUFFLE_PARTITIONS)
 
   def adaptiveAutoCalculateInitialPartitionNum: Boolean =
-    getConf(ADAPTIVE_EXECUTION_AUTOCALCULATEINITIALPARTITIONNUM)
+    getConf(ADAPTIVE_EXECUTION_AUTO_CALCULATE_INITIAL_PARTITION_NUM)
 
   def minBatchesToRetain: Int = getConf(MIN_BATCHES_TO_RETAIN)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -304,6 +304,14 @@ object SQLConf {
         "must be a positive integer.")
       .createWithDefault(500)
 
+  val ADAPTIVE_EXECUTION_AUTOCALCULATEINITIALPARTITIONNUM =
+    buildConf("spark.sql.adaptive.autoCalculateInitialPartitionNum")
+      .doc("When true and adaptive execution is enabled," +
+        " spark will calculate the initial partition number" +
+        " based on the statistics of the needed column.")
+      .booleanConf
+      .createWithDefault(false)
+
   val SUBEXPRESSION_ELIMINATION_ENABLED =
     buildConf("spark.sql.subexpressionElimination.enabled")
       .internal()
@@ -1364,6 +1372,9 @@ class SQLConf extends Serializable with Logging {
   def minNumPostShufflePartitions: Int = getConf(SHUFFLE_MIN_NUM_POSTSHUFFLE_PARTITIONS)
 
   def maxNumPostShufflePartitions: Int = getConf(SHUFFLE_MAX_NUM_POSTSHUFFLE_PARTITIONS)
+
+  def adaptiveAutoCalculateInitialPartitionNum: Boolean =
+    getConf(ADAPTIVE_EXECUTION_AUTOCALCULATEINITIALPARTITIONNUM)
 
   def minBatchesToRetain: Int = getConf(MIN_BATCHES_TO_RETAIN)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -77,8 +77,10 @@ trait DataSourceScanExec extends LeafExecNode with CodegenSupport {
     // There should be some overhead in Row object, the size should not be zero when there is
     // no columns, this help to prevent divide-by-zero error.
     val neededColumnRowSize = this.output.map(_.dataType.defaultSize).sum + 8
-    val allColumnRowSize = relation.schema.map(_.dataType.defaultSize).sum + 8
-    Statistics(sizeInBytes = (relation.sizeInBytes * neededColumnRowSize / allColumnRowSize))
+    val dataSchema = sqlContext.sparkSession.sessionState.catalog.getTableMetadata(
+      tableIdentifier.get).dataSchema
+    val allColumnRowSize = dataSchema.map(_.dataType.defaultSize).sum + 8
+    Statistics(sizeInBytes = ((relation.sizeInBytes * neededColumnRowSize) / allColumnRowSize))
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -76,7 +76,7 @@ trait DataSourceScanExec extends LeafExecNode with CodegenSupport {
   override def computeStats(): Statistics = {
     // There should be some overhead in Row object, the size should not be zero when there is
     // no columns, this help to prevent divide-by-zero error.
-    val outputRowSize = this.output.map(_.dataType.defaultSize).sum + 8
+    val outputRowSize = output.map(_.dataType.defaultSize).sum + 8
     val dataSchema = sqlContext.sparkSession.sessionState.catalog.getTableMetadata(
       tableIdentifier.get).dataSchema
     val totalRowSize = dataSchema.map(_.dataType.defaultSize).sum + 8

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala
@@ -76,11 +76,11 @@ trait DataSourceScanExec extends LeafExecNode with CodegenSupport {
   override def computeStats(): Statistics = {
     // There should be some overhead in Row object, the size should not be zero when there is
     // no columns, this help to prevent divide-by-zero error.
-    val neededColumnRowSize = this.output.map(_.dataType.defaultSize).sum + 8
+    val outputRowSize = this.output.map(_.dataType.defaultSize).sum + 8
     val dataSchema = sqlContext.sparkSession.sessionState.catalog.getTableMetadata(
       tableIdentifier.get).dataSchema
-    val allColumnRowSize = dataSchema.map(_.dataType.defaultSize).sum + 8
-    Statistics(sizeInBytes = ((relation.sizeInBytes * neededColumnRowSize) / allColumnRowSize))
+    val totalRowSize = dataSchema.map(_.dataType.defaultSize).sum + 8
+    Statistics(sizeInBytes = ((relation.sizeInBytes * outputRowSize) / totalRowSize))
   }
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -38,7 +38,7 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
   private def defaultNumPreShufflePartitions(child: SparkPlan): Int =
     if (conf.adaptiveExecutionEnabled) {
       val totalInputFileSize = child.collectLeaves().map(_.stats.sizeInBytes).sum
-      (totalInputFileSize / conf.targetPostShuffleInputSize + 1).toInt
+      Math.ceil((totalInputFileSize / conf.targetPostShuffleInputSize).toDouble).toInt
     } else {
       conf.numShufflePartitions
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.exchange
 
 import scala.collection.mutable.ArrayBuffer
+
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.catalyst.rules.Rule

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -335,7 +335,7 @@ class PlannerSuite extends SharedSQLContext {
         (totalInputFileSize / conf.targetPostShuffleInputSize).toDouble).toInt
 
       withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
-        SQLConf.ADAPTIVE_EXECUTION_AUTOCALCULATEINITIALPARTITIONNUM.key -> "true") {
+        SQLConf.ADAPTIVE_EXECUTION_AUTO_CALCULATE_INITIAL_PARTITION_NUM.key -> "true") {
         val outputPlan = EnsureRequirements(spark.sessionState.conf).apply(inputPlan)
         outputPlan.collect{
           case plan : ShuffleExchangeExec =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -334,7 +334,8 @@ class PlannerSuite extends SharedSQLContext {
       val expectedNum = Math.ceil(
         (totalInputFileSize / conf.targetPostShuffleInputSize).toDouble).toInt
 
-      withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
+      withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+        SQLConf.ADAPTIVE_EXECUTION_AUTOCALCULATEINITIALPARTITIONNUM.key -> "true") {
         val outputPlan = EnsureRequirements(spark.sessionState.conf).apply(inputPlan)
         outputPlan.collect{
           case plan : ShuffleExchangeExec =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -315,6 +315,43 @@ class PlannerSuite extends SharedSQLContext {
     }
   }
 
+  test("EnsureRequirements with the initial partition number") {
+    val distribution = ClusteredDistribution(Literal(1) :: Nil)
+    val childPartitioning = HashPartitioning(Literal(2) :: Nil, 1)
+
+    val inputPlan = DummySparkPlan(
+      children = Seq(
+        DummySparkPlan(outputPartitioning = childPartitioning),
+        DummySparkPlan(outputPartitioning = childPartitioning)
+      ),
+      requiredChildDistribution = Seq(distribution, distribution),
+      requiredChildOrdering = Seq(Seq.empty, Seq.empty)
+    )
+    withSQLConf(SQLConf.SHUFFLE_TARGET_POSTSHUFFLE_INPUT_SIZE.key -> "1") {
+
+      val totalInputFileSize = inputPlan.collectLeaves().map(_.stats.sizeInBytes).sum
+      val expectedNum = (totalInputFileSize / conf.targetPostShuffleInputSize + 1).toInt
+
+      withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
+        val outputPlan = EnsureRequirements(spark.sessionState.conf).apply(inputPlan)
+        outputPlan.collect{
+          case plan : ShuffleExchangeExec =>
+            val realNum = plan.outputPartitioning.numPartitions
+            assert(realNum == expectedNum)
+        }
+      }
+
+      withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
+        val outputPlan = EnsureRequirements(spark.sessionState.conf).apply(inputPlan)
+        outputPlan.collect{
+          case plan : ShuffleExchangeExec =>
+            val realNum = plan.outputPartitioning.numPartitions
+            assert(realNum != expectedNum)
+        }
+      }
+    }
+  }
+
   test("EnsureRequirements with compatible child partitionings that satisfy distribution") {
     // In this case, all requirements are satisfied and no exchange should be added.
     val distribution = ClusteredDistribution(Literal(1) :: Nil)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -315,7 +315,8 @@ class PlannerSuite extends SharedSQLContext {
     }
   }
 
-  test("EnsureRequirements with the initial partition number") {
+  test("EnsureRequirements with the initial partition number that" +
+    " is based on the statistics of leaf node") {
     val distribution = ClusteredDistribution(Literal(1) :: Nil)
     val childPartitioning = HashPartitioning(Literal(2) :: Nil, 1)
 
@@ -330,7 +331,8 @@ class PlannerSuite extends SharedSQLContext {
     withSQLConf(SQLConf.SHUFFLE_TARGET_POSTSHUFFLE_INPUT_SIZE.key -> "1") {
 
       val totalInputFileSize = inputPlan.collectLeaves().map(_.stats.sizeInBytes).sum
-      val expectedNum = (totalInputFileSize / conf.targetPostShuffleInputSize + 1).toInt
+      val expectedNum = Math.ceil(
+        (totalInputFileSize / conf.targetPostShuffleInputSize).toDouble).toInt
 
       withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {
         val outputPlan = EnsureRequirements(spark.sessionState.conf).apply(inputPlan)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/PlannerSuite.scala
@@ -332,7 +332,7 @@ class PlannerSuite extends SharedSQLContext {
 
       val totalInputFileSize = inputPlan.collectLeaves().map(_.stats.sizeInBytes).sum
       val expectedNum = Math.ceil(
-        (totalInputFileSize / conf.targetPostShuffleInputSize).toDouble).toInt
+        totalInputFileSize.toLong * 1.0 / conf.targetPostShuffleInputSize).toInt
 
       withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
         SQLConf.ADAPTIVE_EXECUTION_AUTO_CALCULATE_INITIAL_PARTITION_NUM.key -> "true") {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -21,7 +21,7 @@ import scala.util.control.NonFatal
 
 import com.google.common.util.concurrent.Striped
 import org.apache.hadoop.fs.Path
-
+import org.apache.hadoop.hive.common.StatsSetupConst
 import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
@@ -154,7 +154,14 @@ private[hive] class HiveMetastoreCatalog(sparkSession: SparkSession) extends Log
           Some(partitionSchema))
 
         val logicalRelation = cached.getOrElse {
-          val sizeInBytes = relation.stats.sizeInBytes.toLong
+          // for the partition table, the relation.stats.sizeInBytes is Long.max
+          // not the real size in hdfs
+          val sizeInBytes = if (relation.isPartitioned) {
+            sparkSession.sharedState.externalCatalog.listPartitions(tableIdentifier.database,
+              tableIdentifier.name).map(_.parameters.get(StatsSetupConst.TOTAL_SIZE).get.toLong).sum
+          } else {
+            relation.stats.sizeInBytes.toLong
+          }
           val fileIndex = {
             val index = new CatalogFileIndex(sparkSession, relation.tableMeta, sizeInBytes)
             if (lazyPruningEnabled) {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -156,7 +156,7 @@ private[hive] class HiveMetastoreCatalog(sparkSession: SparkSession) extends Log
         val logicalRelation = cached.getOrElse {
           // for the partition table, the relation.stats.sizeInBytes is Long.max
           // not the real size in hdfs
-          val sizeInBytes = if (relation.isPartitioned) {
+          val sizeInBytes = if (relation.isPartitioned && relation.stats.sizeInBytes.toLong == Long.MaxValue) {
             sparkSession.sharedState.externalCatalog.listPartitions(tableIdentifier.database,
               tableIdentifier.name).map(_.parameters.get(StatsSetupConst.TOTAL_SIZE).get.toLong).sum
           } else {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
@@ -218,7 +218,7 @@ case class HiveTableScanExec(
   override def computeStats(): Statistics = {
     // There should be some overhead in Row object, the size should not be zero when there is
     // no columns, this help to prevent divide-by-zero error.
-    val outputRowSize = this.output.map(_.dataType.defaultSize).sum + 8
+    val outputRowSize = output.map(_.dataType.defaultSize).sum + 8
     val totalRowSize = relation.tableMeta.dataSchema.map(_.dataType.defaultSize).sum + 8
     // For the partition table, we only get the selected partition statistics
     val sizeInBytes = if (relation.isPartitioned && rawPartitions.nonEmpty) {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.hive.execution
 import scala.collection.JavaConverters._
 
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hive.common.StatsSetupConst
 import org.apache.hadoop.hive.ql.metadata.{Partition => HivePartition}
 import org.apache.hadoop.hive.ql.plan.TableDesc
 import org.apache.hadoop.hive.serde.serdeConstants
@@ -215,7 +216,18 @@ case class HiveTableScanExec(
   override def otherCopyArgs: Seq[AnyRef] = Seq(sparkSession)
 
   override def computeStats(): Statistics = {
-    val stats = relation.computeStats()
-    Statistics(stats.sizeInBytes)
+    // There should be some overhead in Row object, the size should not be zero when there is
+    // no columns, this help to prevent divide-by-zero error.
+    val neededColumnRowSize = this.output.map(_.dataType.defaultSize).sum + 8
+    val allColumnRowSize = relation.tableMeta.dataSchema.map(_.dataType.defaultSize).sum + 8
+    // For the partition table, we only get the selected partition statistics
+    val sizeInBytes = if (relation.isPartitioned && rawPartitions.nonEmpty) {
+      BigInt(rawPartitions.map(_.getParameters.get(StatsSetupConst.TOTAL_SIZE).toLong).sum)
+    } else {
+      relation.computeStats().sizeInBytes
+    }
+    // the sizeInBytes is the compressed size and we need multiply the compressionFactor
+    val compressionFactor = sparkSession.sessionState.conf.fileCompressionFactor.toLong
+    Statistics((sizeInBytes * compressionFactor * neededColumnRowSize) / allColumnRowSize)
   }
 }

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/execution/HiveTableScanExec.scala
@@ -218,8 +218,8 @@ case class HiveTableScanExec(
   override def computeStats(): Statistics = {
     // There should be some overhead in Row object, the size should not be zero when there is
     // no columns, this help to prevent divide-by-zero error.
-    val neededColumnRowSize = this.output.map(_.dataType.defaultSize).sum + 8
-    val allColumnRowSize = relation.tableMeta.dataSchema.map(_.dataType.defaultSize).sum + 8
+    val outputRowSize = this.output.map(_.dataType.defaultSize).sum + 8
+    val totalRowSize = relation.tableMeta.dataSchema.map(_.dataType.defaultSize).sum + 8
     // For the partition table, we only get the selected partition statistics
     val sizeInBytes = if (relation.isPartitioned && rawPartitions.nonEmpty) {
       BigInt(rawPartitions.map(_.getParameters.get(StatsSetupConst.TOTAL_SIZE).toLong).sum)
@@ -228,6 +228,6 @@ case class HiveTableScanExec(
     }
     // the sizeInBytes is the compressed size and we need multiply the compressionFactor
     val compressionFactor = sparkSession.sessionState.conf.fileCompressionFactor.toLong
-    Statistics((sizeInBytes * compressionFactor * neededColumnRowSize) / allColumnRowSize)
+    Statistics((sizeInBytes * compressionFactor * outputRowSize) / totalRowSize)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, ae set the max  initial partition number by the configuration of "spark.sql.adaptive.maxNumPostShufflePartitions"  and the value is often estimated. This PR  auto calculate the partition number based on the statics of leaf node in SparkPlan. 
 
Method:
We count the statics of leaf node in EnsureRequirements#defaultNumPreShufflePartitions method and the partition number is equal to the value of statics divided by "spark.sql.adaptive.shuffle.targetPostShuffleInputSize".

## How was this patch tested?

UT in PlannerSuite.scala