### PR TITLE
disable auto calculate the reduce number when the pre-shuffle partition number is not same

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala
@@ -109,7 +109,9 @@ abstract class QueryStage extends UnaryExecNode {
     }
     val childMapOutputStatistics = queryStageInputs.map(_.childStage.mapOutputStatistics)
       .filter(_ != null).toArray
-    if (childMapOutputStatistics.length > 0) {
+    // Make sure we do get the same number of pre-shuffle partitions for those stages.
+    if (childMapOutputStatistics.length > 0 &&
+      childMapOutputStatistics.map(stats => stats.bytesByPartitionId.length).distinct.length == 1) {
       val exchangeCoordinator = new ExchangeCoordinator(
         conf.targetPostShuffleInputSize,
         conf.adaptiveTargetPostShuffleRowCount,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala
@@ -24,7 +24,7 @@ import org.apache.spark.{broadcast, MapOutputStatistics, SparkContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partitioning, PartitioningCollection}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.execution.ui.SparkListenerSQLAdaptiveExecutionUpdate
@@ -109,9 +109,17 @@ abstract class QueryStage extends UnaryExecNode {
     }
     val childMapOutputStatistics = queryStageInputs.map(_.childStage.mapOutputStatistics)
       .filter(_ != null).toArray
-    // Make sure we do get the same number of pre-shuffle partitions for those stages.
-    if (childMapOutputStatistics.length > 0 &&
-      childMapOutputStatistics.map(stats => stats.bytesByPartitionId.length).distinct.length == 1) {
+    // Right now, Adaptive execution only support HashPartitionings.
+    val supportAdaptive = queryStageInputs.forall{
+        _.outputPartitioning match {
+          case hash: HashPartitioning => true
+          case collection: PartitioningCollection =>
+            collection.partitionings.forall(_.isInstanceOf[HashPartitioning])
+          case _ => false
+        }
+    }
+
+    if (childMapOutputStatistics.length > 0 && supportAdaptive) {
       val exchangeCoordinator = new ExchangeCoordinator(
         conf.targetPostShuffleInputSize,
         conf.adaptiveTargetPostShuffleRowCount,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
@@ -103,7 +103,7 @@ class ExchangeCoordinator(
 
     // Make sure we do get the same number of pre-shuffle partitions for those stages.
     val distinctNumPreShufflePartitions =
-    mapOutputStatistics.map(stats => stats.bytesByPartitionId.length).distinct
+      mapOutputStatistics.map(stats => stats.bytesByPartitionId.length).distinct
     // The reason that we are expecting a single value of the number of pre-shuffle partitions
     // is that when we add Exchanges, we set the number of pre-shuffle partitions
     // (i.e. map output partitions) using a static setting, which is the value of

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala
@@ -101,20 +101,8 @@ class ExchangeCoordinator(
       s"advisoryTargetPostShuffleInputSize: $advisoryTargetPostShuffleInputSize, " +
       s"targetPostShuffleInputSize $targetPostShuffleInputSize. ")
 
-    // Make sure we do get the same number of pre-shuffle partitions for those stages.
-    val distinctNumPreShufflePartitions =
-      mapOutputStatistics.map(stats => stats.bytesByPartitionId.length).distinct
-    // The reason that we are expecting a single value of the number of pre-shuffle partitions
-    // is that when we add Exchanges, we set the number of pre-shuffle partitions
-    // (i.e. map output partitions) using a static setting, which is the value of
-    // spark.sql.shuffle.partitions. Even if two input RDDs are having different
-    // number of partitions, they will have the same number of pre-shuffle partitions
-    // (i.e. map output partitions).
-    assert(
-      distinctNumPreShufflePartitions.length == 1,
-      "There should be only one distinct value of the number pre-shuffle partitions " +
-        "among registered Exchange operator.")
-    val numPreShufflePartitions = distinctNumPreShufflePartitions.head
+    val numPreShufflePartitions =
+      mapOutputStatistics.map(stats => stats.bytesByPartitionId.length).distinct.head
 
     val partitionStartIndices = ArrayBuffer[Int]()
     val partitionEndIndices = ArrayBuffer[Int]()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/QueryStageSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/QueryStageSuite.scala
@@ -703,4 +703,18 @@ class QueryStageSuite extends SparkFunSuite with BeforeAndAfterAll {
       assert(answer === expect)
     }
   }
+
+  test("different pre-shuffle partition number") {
+    val spark = defaultSparkSession
+    import spark.implicits._
+    spark.sql(s"""CREATE table test (age INT, name STRING)
+            | USING parquet""".stripMargin)
+    val data: Seq[(Int, String)] = (1 to 2).map { i => (i, s"this is test $i") }
+    data.toDF("key", "value").createOrReplaceTempView("t")
+    spark.sql("insert overwrite table test select * from t")
+
+    checkAnswer(spark.sql("select count(test.age) from test group by test.name" +
+      " union all select count(test.age) from test"),
+      Row(1) :: Row(1) :: Row(2) :: Nil)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, ae will auto calculate the reduce number when the pre-shuffle partition number is same. And if the pre-shuffle partition number is not same, it will throw an AssertError in ExchangeCoordinator.scala. 
For example:
![image](https://user-images.githubusercontent.com/11972570/44450390-61d1b680-a623-11e8-9cbc-d8e3f659ad72.png)
It will throw the following error:
![image](https://user-images.githubusercontent.com/11972570/44450514-bbd27c00-a623-11e8-91d7-df8ec9995da6.png)
Reason:
The left sql is count + group by clause and the right is only count clause. And  the count + group by clause will be converted to ClusteredDistribution if the group by attribute is not null (https://github.com/Intel-bigdata/spark-adaptive/blob/dc7ba14d8b95599d3c2803e25d861aeada642a32/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala#L78) and the count clause be converted to AllTuples if the group by attribute is null ( https://github.com/Intel-bigdata/spark-adaptive/blob/dc7ba14d8b95599d3c2803e25d861aeada642a32/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala#L77) based on the requiredChildDistributionExpressions. And the requiredChildDistributionExpressions is based on the 
the groupingAttributes ( https://github.com/apache/spark/blob/55f36641ff20114b892795f100da7efb79b0cc32/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/AggUtils.scala#L108 ). So for the count + group by clause, the partition number is 500 and the partition number of count clause is 1. Therefore, it throw assert error(https://github.com/Intel-bigdata/spark-adaptive/blob/dc7ba14d8b95599d3c2803e25d861aeada642a32/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ExchangeCoordinator.scala#L113 )

What we changed is : 

1.  Disable the feature of auto calculate reduce number when the pre-shuffle partition number is not same in QueryStage.scala;
2.  Remove the duplicated judgment of the number of pre-shuffle partition in ExchangeCoordinator.scala

## How was this patch tested?
add ut in QueryStageSuite.scala
