### PR TITLE
Optimize the initial partition num after PlanQueryStage

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.analysis.UnsupportedOperationChecker
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, ReturnAnswer}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
-import org.apache.spark.sql.execution.adaptive.PlanQueryStage
+import org.apache.spark.sql.execution.adaptive.{OptimizeInitialPartitionNum, PlanQueryStage}
 import org.apache.spark.sql.execution.command.{DescribeTableCommand, ExecutedCommandExec, ShowTablesCommand}
 import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ReuseExchange}
 import org.apache.spark.sql.types.{BinaryType, DateType, DecimalType, TimestampType, _}
@@ -109,7 +109,9 @@ class QueryExecution(val sparkSession: SparkSession, val logical: LogicalPlan) {
     // PlanQueryStage needs to be the last rule because it divides the plan into multiple sub-trees
     // by inserting leaf node QueryStageInput. Transforming the plan after applying this rule will
     // only transform node in a sub-tree.
-    PlanQueryStage(sparkSession.sessionState.conf))
+    PlanQueryStage(sparkSession.sessionState.conf),
+    // Optimize the initial partition num after PlanQueryStage
+    OptimizeInitialPartitionNum(sparkSession.sessionState.conf))
 
   protected def stringOrError[A](f: => A): String =
     try f.toString catch { case e: AnalysisException => e.toString }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeInitialPartitionNum.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeInitialPartitionNum.scala
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.adaptive
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, PartitioningCollection}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StructType
+
+case class OptimizeInitialPartitionNum(conf: SQLConf) extends Rule[SparkPlan] {
+
+  private def autoCalculateInitialPartitionNum(totalInputSize: BigInt): Int = {
+    val autoInitialPartitionsNum = Math.ceil(
+      totalInputSize.toLong * 1.0 / conf.targetPostShuffleInputSize).toInt
+    if (autoInitialPartitionsNum < conf.minNumPostShufflePartitions) {
+      conf.minNumPostShufflePartitions
+    } else if (autoInitialPartitionsNum > conf.maxNumPostShufflePartitions) {
+      conf.maxNumPostShufflePartitions
+    } else {
+      autoInitialPartitionsNum
+    }
+  }
+
+  private def optimizeInitialPartitionNum(
+    plan: SparkPlan,
+    reuseStages: mutable.HashMap[StructType, ArrayBuffer[ShuffleQueryStage]] = null): SparkPlan = {
+    val oldPlan = plan
+    val shuffleQueryStages: Seq[ShuffleQueryStage] = plan.collect {
+      case input: ShuffleQueryStageInput => input.childStage
+    }
+    if (shuffleQueryStages.nonEmpty) {
+      val initialPartitionNum = if (conf.adaptiveAutoCalculateInitialPartitionNum) {
+        val totalInputSize = shuffleQueryStages.map {
+          shuffleQueryStage: ShuffleQueryStage =>
+            val child = shuffleQueryStage.child.asInstanceOf[ShuffleExchangeExec].child
+            child.stats.sizeInBytes
+        }.sum
+        autoCalculateInitialPartitionNum(totalInputSize)
+      } else {
+        conf.maxNumPostShufflePartitions
+      }
+
+      if (reuseStages != null) {
+        // "spark.sql.exchange.reuse" is true.There may exist duplicated exchanges
+        shuffleQueryStages.foreach {
+          shuffleQueryStage: ShuffleQueryStage =>
+            val sameSchema = reuseStages.getOrElseUpdate(
+              shuffleQueryStage.child.schema, ArrayBuffer[ShuffleQueryStage]())
+            val samePlan = sameSchema.find { s => shuffleQueryStage.child.sameResult(s.child) }
+            if (samePlan.isDefined) {
+              // the shuffleQueryStage is re-used
+              shuffleQueryStage.outputPartitioning match {
+                case hash: HashPartitioning =>
+                  if (hash.numPartitions < initialPartitionNum) {
+                    hash.copy(numPartitions = initialPartitionNum)
+                  }
+                case collection: PartitioningCollection =>
+                  collection.partitionings match {
+                    case hash: HashPartitioning =>
+                      if (hash.numPartitions < initialPartitionNum) {
+                        hash.copy(numPartitions = initialPartitionNum)
+                      }
+                  }
+                case _ => shuffleQueryStage.outputPartitioning
+              }
+            } else {
+              // the shuffleQueryStage is not re-used
+              shuffleQueryStage.outputPartitioning match {
+                case hash: HashPartitioning => hash.copy(
+                  numPartitions = initialPartitionNum)
+                case collection: PartitioningCollection =>
+                  collection.partitionings match {
+                    case hash: HashPartitioning => hash.copy(
+                      numPartitions = initialPartitionNum)
+                  }
+                case _ => shuffleQueryStage.outputPartitioning
+              }
+              sameSchema += shuffleQueryStage
+            }
+        }
+      } else {
+        // "spark.sql.exchange.reuse" is false.
+        shuffleQueryStages.foreach {
+          shuffleQueryStage: ShuffleQueryStage =>
+            shuffleQueryStage.outputPartitioning match {
+              case hash: HashPartitioning => hash.copy(
+                numPartitions = initialPartitionNum)
+              case collection: PartitioningCollection =>
+                collection.partitionings match {
+                  case hash: HashPartitioning => hash.copy(
+                    numPartitions = initialPartitionNum)
+                }
+              case _ => shuffleQueryStage.outputPartitioning
+            }
+        }
+      }
+      shuffleQueryStages.foreach(optimizeInitialPartitionNum(_, reuseStages))
+    }
+    oldPlan
+  }
+
+  private def adjustInitialPartitionNumSameStage(plan: SparkPlan): SparkPlan = {
+    val oldPlan = plan
+    val shuffleQueryStages: Seq[ShuffleQueryStage] = plan.collect {
+      case input: ShuffleQueryStageInput => input.childStage
+    }
+    if (shuffleQueryStages.nonEmpty) {
+      if (shuffleQueryStages.map(_.outputPartitioning.numPartitions).distinct.length != 1) {
+        val max = shuffleQueryStages.map(_.outputPartitioning.numPartitions).max
+        shuffleQueryStages.foreach {
+          shuffleQueryStage: ShuffleQueryStage =>
+            shuffleQueryStage.outputPartitioning match {
+              case hash: HashPartitioning => hash.copy(
+                numPartitions = max)
+              case collection: PartitioningCollection =>
+                collection.partitionings match {
+                  case hash: HashPartitioning => hash.copy(
+                    numPartitions = max)
+                }
+              case _ => shuffleQueryStage.outputPartitioning
+            }
+        }
+      }
+      shuffleQueryStages.foreach(adjustInitialPartitionNumSameStage(_))
+    }
+    oldPlan
+  }
+
+  def apply(plan: SparkPlan): SparkPlan = {
+
+    val newPlan = if (!conf.exchangeReuseEnabled) {
+      optimizeInitialPartitionNum(plan)
+    } else {
+      // Build a hash map using schema of exchanges to avoid O(N*N) sameResult calls.
+      val stages = mutable.HashMap[StructType, ArrayBuffer[ShuffleQueryStage]]()
+      optimizeInitialPartitionNum(plan, stages)
+      // For the shuffleQueryStage reuse situation, we should adjust the initial partition
+      // to be equal in same stage.
+      adjustInitialPartitionNumSameStage(plan)
+    }
+    newPlan
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.exchange
 
-
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.catalyst.expressions._
@@ -35,31 +34,14 @@ import org.apache.spark.sql.internal.SQLConf
  * the input partition ordering requirements are met.
  */
 case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
-  private def defaultNumPreShufflePartitions(plan: SparkPlan): Int =
+  private def defaultNumPreShufflePartitions(): Int =
     if (conf.adaptiveExecutionEnabled) {
-      if (conf.adaptiveAutoCalculateInitialPartitionNum) {
-        autoCalculateInitialPartitionNum(plan)
-      } else {
-        conf.maxNumPostShufflePartitions
-      }
+      conf.minNumPostShufflePartitions
     } else {
       conf.numShufflePartitions
     }
 
-  private def autoCalculateInitialPartitionNum(plan: SparkPlan): Int = {
-    val totalInputFileSize = plan.collectLeaves().map(_.stats.sizeInBytes).sum
-    val autoInitialPartitionsNum = Math.ceil(
-      totalInputFileSize.toLong * 1.0 / conf.targetPostShuffleInputSize).toInt
-    if (autoInitialPartitionsNum < conf.minNumPostShufflePartitions) {
-      conf.minNumPostShufflePartitions
-    } else if (autoInitialPartitionsNum > conf.maxNumPostShufflePartitions) {
-      conf.maxNumPostShufflePartitions
-    } else {
-      autoInitialPartitionsNum
-    }
-  }
-
-  private def ensureDistributionAndOrdering(operator: SparkPlan, rootNode: SparkPlan): SparkPlan = {
+  private def ensureDistributionAndOrdering(operator: SparkPlan): SparkPlan = {
     val requiredChildDistributions: Seq[Distribution] = operator.requiredChildDistribution
     val requiredChildOrderings: Seq[Seq[SortOrder]] = operator.requiredChildOrdering
     var children: Seq[SparkPlan] = operator.children
@@ -74,7 +56,7 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
         BroadcastExchangeExec(mode, child)
       case (child, distribution) =>
         val numPartitions = distribution.requiredNumPartitions
-          .getOrElse(defaultNumPreShufflePartitions(rootNode))
+          .getOrElse(defaultNumPreShufflePartitions())
         ShuffleExchangeExec(distribution.createPartitioning(numPartitions), child)
     }
 
@@ -203,11 +185,7 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
     }
   }
 
-  def apply(plan: SparkPlan): SparkPlan = {
-    // Record the rootNode is order to collect all the leaves node of the rootNode
-    // when calculate the initial partition num
-    val rootNode = plan;
-    plan.transformUp {
+  def apply(plan: SparkPlan): SparkPlan = plan.transformUp {
       // TODO: remove this after we create a physical operator for `RepartitionByExpression`.
       case operator @ ShuffleExchangeExec(upper: HashPartitioning, child) =>
         child.outputPartitioning match {
@@ -215,7 +193,6 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
           case _ => operator
         }
       case operator: SparkPlan =>
-        ensureDistributionAndOrdering(reorderJoinPredicates(operator), rootNode)
+        ensureDistributionAndOrdering(reorderJoinPredicates(operator))
     }
-  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, the method of calculating the initial partition num is by collecting all the statistics of  leaves node when enable "spark.sql.adaptive.autoCalculateInitialPartitionNum". The described method is not perfect and this pr is working on optimizing the estimation of initial partition num by the statistics of pre-stages in plan. 

What we changed:
 **OptimizeInitialPartitionNum.scala:**  Add this new class to optimize the initial partition num

- **optimizeInitialPartitionNum method:** collect all the pre-stages(ShuffleQueryStage) and calculate the initial partition num for pre-stages based on the statistics of the input of all pre-stages. For the reuse exchange, we remain the max initial partition num.
   

- **adjustInitialPartitionNumSameStage method**:  For the reuse exchange, the initial partition num in same stage may be not same. We adjust the initial partition num to be same.

**QueryExcution.scala**:Add OptimizeInitialPartitionNum optimization after PlanQueryStage.

**EnsureRequirements.scala**:We set the initial partition num to minNumPostShufflePartitions in EnsureRequirements and adjust the num in OptimizeInitialPartitionNum
## How was this patch tested?
will add later
