### PR TITLE
Avoid broadcasting tables whose size exceeds adaptiveBroadcastJoinThreshold

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -238,12 +238,6 @@ object SQLConf {
     .longConf
     .createOptional
 
-  val ADAPTIVE_BROADCASTJOIN_USEMETRIC = buildConf("spark.sql.adaptive.broadcastjoin.usemetric")
-    .doc("When true, consider SQL metrics when determining whether to adapt a sort/merge join " +
-      "to a broadcast join.")
-    .booleanConf
-    .createWithDefault(false)
-
   val ADAPTIVE_EXECUTION_ALLOW_ADDITIONAL_SHUFFLE =
     buildConf("spark.sql.adaptive.allowAdditionalShuffle")
       .doc("When true, additional shuffles are allowed during plan optimizations in adaptive " +
@@ -1366,9 +1360,6 @@ class SQLConf extends Serializable with Logging {
 
   def adaptiveBroadcastJoinThreshold: Long =
     getConf(ADAPTIVE_BROADCASTJOIN_THRESHOLD).getOrElse(autoBroadcastJoinThreshold)
-
-  def adaptiveBroadcastJoinUseMetric: Boolean =
-    getConf(ADAPTIVE_BROADCASTJOIN_USEMETRIC)
 
   def adaptiveAllowAdditionShuffle: Boolean = getConf(ADAPTIVE_EXECUTION_ALLOW_ADDITIONAL_SHUFFLE)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -238,6 +238,12 @@ object SQLConf {
     .longConf
     .createOptional
 
+  val ADAPTIVE_BROADCASTJOIN_USEMETRIC = buildConf("spark.sql.adaptive.broadcastjoin.usemetric")
+    .doc("When true, consider SQL metrics when determining whether to adapt a sort/merge join " +
+      "to a broadcast join.")
+    .booleanConf
+    .createWithDefault(false)
+
   val ADAPTIVE_EXECUTION_ALLOW_ADDITIONAL_SHUFFLE =
     buildConf("spark.sql.adaptive.allowAdditionalShuffle")
       .doc("When true, additional shuffles are allowed during plan optimizations in adaptive " +
@@ -1360,6 +1366,9 @@ class SQLConf extends Serializable with Logging {
 
   def adaptiveBroadcastJoinThreshold: Long =
     getConf(ADAPTIVE_BROADCASTJOIN_THRESHOLD).getOrElse(autoBroadcastJoinThreshold)
+
+  def adaptiveBroadcastJoinUseMetric: Boolean =
+    getConf(ADAPTIVE_BROADCASTJOIN_USEMETRIC)
 
   def adaptiveAllowAdditionShuffle: Boolean = getConf(ADAPTIVE_EXECUTION_ALLOW_ADDITIONAL_SHUFFLE)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
@@ -112,9 +112,6 @@ object SizeInBytesOnlyStatsPlanVisitor extends SparkPlanVisitor[Statistics] {
     if (p.mapOutputStatistics != null) {
       val childDataSize = p.child.metrics.get("dataSize").map(_.value).getOrElse(0L)
       val sizeInBytes = p.mapOutputStatistics.bytesByPartitionId.sum.max(childDataSize)
-      if (sizeInBytes == childDataSize) {
-        print(s"Using child data size $childDataSize\n")
-      }
       val bytesByPartitionId = p.mapOutputStatistics.bytesByPartitionId
       if (p.mapOutputStatistics.recordsByPartitionId.nonEmpty) {
         val record = p.mapOutputStatistics.recordsByPartitionId.sum

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/QueryStageSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/QueryStageSuite.scala
@@ -55,7 +55,7 @@ class QueryStageSuite extends SparkFunSuite with BeforeAndAfterAll {
       .config(config.SHUFFLE_STATISTICS_VERBOSE.key, "true")
       .config(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
       .config(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
-      .config(SQLConf.ADAPTIVE_BROADCASTJOIN_THRESHOLD.key, "12000")
+      .config(SQLConf.ADAPTIVE_BROADCASTJOIN_THRESHOLD.key, "16000")
       .getOrCreate()
     spark
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use the dataSize metric from the Exchange operator when deciding whether to convert a sort/merge join to a broadcast join. This prevents Spark from broadcasting a table whose size exceeds the value specified in spark.sql.adaptiveBroadcastJoinThreshold.

Map output can be highly compressed: therefore, map output statistics should not be used when determining join type. The dataSize metric, on the other hand, is the sum of the sizes of the output rows.

This is similar to #57, except that the size is calculated from actual row sizes, rather than using default sizes of data types.

The dataSize metric is calculated in the [serializer](https://github.com/Intel-bigdata/spark-adaptive/blob/ae-2.3.2-08/sql/core/src/main/scala/org/apache/spark/sql/execution/UnsafeRowSerializer.scala#L66) that serializes map output. It simply adds up the sizes of the UnsafeRows. The dataSize metric is an AccumulatorV2 object with countFailedValues set to false. This means that the final merged value in the driver will be made up of values from successful tasks only. Failed tasks and tasks killed during speculation are not counted.

Note: The value in the Exchange nodes in the UI *will* include retried tasks and speculative tasks, even though it uses the same metric. That's because the UI does not use the final merged value: It uses live updates from the executors.

## How was this patch tested?

- Ran unit tests
- Tested with tables that appear tiny on disk, but are quite large in memory. Noted that without this patch, Spark converts the join to a broadcast join, but with the patch it does not (until I increase spark.sql.adaptiveBroadcastJoinThreshold to the actual table size).
- Tested with retried tasks and speculative tasks to confirm no double-counting.

