### PR TITLE
Change reduce number when all leaf nodes are shuffle querystages and not local shuffles

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/QueryStageSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/QueryStageSuite.scala
@@ -262,6 +262,75 @@ class QueryStageSuite extends SparkFunSuite with BeforeAndAfterAll {
     }
   }
 
+  test("One of two sort merge inner joins to broadcast join") {
+    // t1 is smaller than spark.sql.adaptiveBroadcastJoinThreshold
+    // t2 and t3 are greater than spark.sql.adaptiveBroadcastJoinThreshold
+    // Join1 is changed to broadcast join.
+    //
+    //              Join2
+    //              /   \
+    //          Join1   Ex (Exchange)
+    //          /   \    \
+    //        Ex    Ex   t3
+    //       /       \
+    //      t1       t2
+    val spark = defaultSparkSession
+    spark.conf.set(SQLConf.ADAPTIVE_EXECUTION_ALLOW_ADDITIONAL_SHUFFLE.key, "true")
+    withSparkSession(spark) { spark: SparkSession =>
+      val df1 =
+        spark
+          .range(0, 1000, 1, numInputPartitions)
+          .selectExpr("id % 500 as key1", "id as value1")
+      val df2 =
+        spark
+          .range(0, 1000, 1, numInputPartitions)
+          .selectExpr("id % 500 as key2", "id as value2")
+      val df3 =
+        spark
+          .range(0, 1500, 1, numInputPartitions)
+          .selectExpr("id % 500 as key3", "id as value3")
+
+      val join =
+        df1
+          .join(df2, col("key1") === col("key2"))
+          .join(df3, col("key2") === col("key3"))
+          .select(col("key3"), col("value1"))
+
+      // Before Execution, there is two SortMergeJoins
+      val smjBeforeExecution = join.queryExecution.executedPlan.collect {
+        case smj: SortMergeJoinExec => smj
+      }
+      assert(smjBeforeExecution.length === 2)
+
+      // Check the answer.
+      val partResult =
+        spark
+          .range(0, 1000)
+          .selectExpr("id % 500 as key", "id as value")
+          .union(spark.range(0, 1000).selectExpr("id % 500 as key", "id as value"))
+      val expectedAnswer = partResult.union(partResult).union(partResult)
+      checkAnswer(
+        join,
+        expectedAnswer.collect())
+
+      // During execution, one SortMergeJoin is changed to BroadcastHashJoin
+      val numSmjAfterExecution = join.queryExecution.executedPlan.collect {
+        case smj: SortMergeJoinExec => smj
+      }.length
+      assert(numSmjAfterExecution === 1)
+
+      val numBhjAfterExecution = join.queryExecution.executedPlan.collect {
+        case bhj: BroadcastHashJoinExec => bhj
+      }.length
+      assert(numBhjAfterExecution === 1)
+
+      val queryStageInputs = join.queryExecution.executedPlan.collect {
+        case q: QueryStageInput => q
+      }
+      assert(queryStageInputs.length === 3)
+    }
+  }
+
   test("Reuse QueryStage in adaptive execution") {
     withSparkSession(defaultSparkSession) { spark: SparkSession =>
       val df = spark.range(0, 1000, 1, numInputPartitions).toDF()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Backport [#PR81](https://github.com/Intel-bigdata/spark-adaptive/pull/81) to branch-0.6-spark-2.3.0

## How was this patch tested?
Add new unit test