### PR TITLE
fix the none exception when the metastore has no TOTAL_SIZE

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -206,7 +206,7 @@ case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
   def apply(plan: SparkPlan): SparkPlan = {
     // Record the rootNode is order to collect all the leaves node of the rootNode
     // when calculate the initial partition num
-    val rootNode = plan;
+    val rootNode = plan
     plan.transformUp {
       // TODO: remove this after we create a physical operator for `RepartitionByExpression`.
       case operator @ ShuffleExchangeExec(upper: HashPartitioning, child) =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveMetastoreCatalog.scala
@@ -157,8 +157,15 @@ private[hive] class HiveMetastoreCatalog(sparkSession: SparkSession) extends Log
           // for the partition table, the relation.stats.sizeInBytes is Long.max
           // not the real size in hdfs
           val sizeInBytes = if (relation.isPartitioned && relation.stats.sizeInBytes.toLong == Long.MaxValue) {
-            sparkSession.sharedState.externalCatalog.listPartitions(tableIdentifier.database,
-              tableIdentifier.name).map(_.parameters.get(StatsSetupConst.TOTAL_SIZE).get.toLong).sum
+            val partitions = sparkSession.sharedState.externalCatalog.listPartitions(
+              tableIdentifier.database, tableIdentifier.name)
+            val size = if (partitions.filter(
+              _.parameters.contains(StatsSetupConst.TOTAL_SIZE)).length == partitions.length) {
+              partitions.map(_.parameters.get(StatsSetupConst.TOTAL_SIZE).get.toLong).sum
+            } else {
+              Long.MaxValue
+            }
+            size
           } else {
             relation.stats.sizeInBytes.toLong
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?
When we estimate the initial partition num, for the partition table, we need get the partition size from the parameter "TOTAL_SIZE" in hive metastore.  When hive metastore does not have the parameter "TOTAL_SIZE", it will throw "None.get exception". This PR adds a check of whether hive metastore have the "TOTAL_SIZE" parameter.

## How was this patch tested?
existing ut
