### PR TITLE
Optimize sortMergeJoin to shuffledHashJoin with spark adaptive execut…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -238,6 +238,35 @@ object SQLConf {
     .longConf
     .createOptional
 
+  val ADAPTIVE_EXECUTION_HASHJOIN_ENABLED = buildConf("spark.sql.adaptive.hashJoin.enabled")
+    .doc("When true and adaptive execution is enabled, hash join strategy is determined at " +
+      "runtime.")
+    .booleanConf
+    .createWithDefault(false)
+
+  val ADAPTIVE_HASHJOIN_THRESHOLD = buildConf("spark.sql.adaptiveHashJoinThreshold")
+    .doc("Configures the maximum size in bytes for each shuffle partition that can use hash join " +
+      "when performing a join in adaptive exeuction mode. If not set, it equals to " +
+      "spark.sql.autoBroadcastJoinThreshold.")
+    .longConf
+    .createOptional
+
+  val ADAPTIVE_HASHJOIN_MAX_PARTITION_FACTOR = buildConf("spark.sql.adaptiveHashJoin.maxPartitionFactor")
+    .doc("One stage of sortMergeJoin if max partition size is less than this factor multiple spark.sql.adaptiveHashJoinThreshold " +
+      "and all partitions' size is less than spark.sql.adaptiveHashJoin.allPartitionFactor multiple " +
+      "spark.sql.adaptiveHashJoinThreshold * spark.sql.adaptive.maxNumPostShufflePartitions, " +
+      "then this sortMergeJoin can be optimized to shuffledHashJoin")
+    .doubleConf
+    .createWithDefault(4.0)
+
+  val ADAPTIVE_HASHJOIN_ALL_PARTITIONS_FACTOR = buildConf("spark.sql.adaptiveHashJoin.allPartitionFactor")
+    .doc("One stage of sortMergeJoin if all partitions' size is less than this factor multiple " +
+      "spark.sql.adaptiveHashJoinThreshold * spark.sql.adaptive.maxNumPostShufflePartitions" +
+      "and max partition size is less than spark.sql.adaptiveHashJoin.maxPartitionFactor multiple spark.sql.adaptiveHashJoinThreshold, " +
+      "then this sortMergeJoin can be optimized to shuffledHashJoin")
+    .doubleConf
+    .createWithDefault(0.5)
+
   val ADAPTIVE_EXECUTION_ALLOW_ADDITIONAL_SHUFFLE =
     buildConf("spark.sql.adaptive.allowAdditionalShuffle")
       .doc("When true, additional shuffles are allowed during plan optimizations in adaptive " +
@@ -1368,6 +1397,15 @@ class SQLConf extends Serializable with Logging {
 
   def adaptiveBroadcastJoinThreshold: Long =
     getConf(ADAPTIVE_BROADCASTJOIN_THRESHOLD).getOrElse(autoBroadcastJoinThreshold)
+
+  def adaptiveHashJoinEnabled: Boolean = getConf(ADAPTIVE_EXECUTION_HASHJOIN_ENABLED)
+
+  def adaptiveHashJoinThreshold: Long =
+    getConf(ADAPTIVE_HASHJOIN_THRESHOLD).getOrElse(autoBroadcastJoinThreshold)
+
+  def adaptiveHashJoinMaxPartitionFactor: Double = getConf(ADAPTIVE_HASHJOIN_MAX_PARTITION_FACTOR)
+
+  def adaptiveHashJoinAllPartitionsFactor: Double = getConf(ADAPTIVE_HASHJOIN_ALL_PARTITIONS_FACTOR)
 
   def adaptiveAllowAdditionShuffle: Boolean = getConf(ADAPTIVE_EXECUTION_ALLOW_ADDITIONAL_SHUFFLE)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, when set spark.sql.adaptive.join.enabled=true and one table's maximum size in bytes  is smaller than spark.sql.adaptiveBroadcastJoinThreshold, spark AE can optimize sort merge join to broadcast join.But in most instances, the maximum size in bytes for any one table of one join are bigger than  spark.sql.adaptiveBroadcastJoinThreshold, these joins can not be transformed to broadcast join. And we found that maximum size in bytes of every shuffle partition is smaller enough after filtering, and the partition's row data can be loaded into memory using shuffledHashJoin to speed up join process.

What we changed:
    **SQLConf.scala**:  add some confs to control whether transformed sortMergeJoin to shuffledHashJoin or not 
    **OptimizeJoin.scala**: if sortMergeJoin don't be transformed to broadcastJoin, then try to transform to shuffledHashJoin
        **canBuildLocalHashMap method**: When maximum size in bytes of every shuffle partition is smaller enough to build hash map in memory, return true, other wise return false
        **isHashJoinThresholdOverPostShuffleInputSize method**: When spark.sql.adaptive.shuffle.targetPostShuffleInputSize is bigger than spark.sql.adaptiveHashJoinThreshold, the maximum size in bytes of reduce task may be greater than spark.sql.adaptive.shuffle.targetPostShuffleInputSize after reducing task number. So we need to guarantee spark.sql.adaptiveHashJoinThreshold is equal or bigger than spark.sql.adaptive.shuffle.targetPostShuffleInputSize
    **QueryStage.scala**: After sortMergeJoin transforming to ShuffledHashJoin, the additional Exchange may be added, it will lead to the second SortMergeJoin's children can't satify their output distribution requirements, so add some conditions to check whether the plan is changed, if the plan is changed, disable change reduce number.

## How was this patch tested?
Unit tests and manually tests.
