### PR TITLE
Fix the hang issue when oom issue in broadcast stage

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partition
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.execution.ui.SparkListenerSQLAdaptiveExecutionUpdate
-import org.apache.spark.util.ThreadUtils
+import org.apache.spark.util.{SparkUncaughtExceptionHandler, ThreadUtils}
 
 /**
  * In adaptive execution mode, an execution plan is divided into multiple QueryStages. Each
@@ -97,6 +97,11 @@ abstract class QueryStage extends UnaryExecNode {
     if (prepared) {
       return
     }
+
+    // set the uncaughtExceptionHandler to catch the exception of child thread in the
+    // parent thread and then prevent the hang issue
+    Thread.setDefaultUncaughtExceptionHandler(new SparkUncaughtExceptionHandler())
+
     // 1. Execute childStages
     executeChildStages()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
For q23a in 3TB TPC-DS, when we enable AE and set the broadcast threshold to 100M, the following OOM issue will occur during building the hash table and the application will always hang. This PR set the uncaughtExceptionHandler in the parent thread and then will catch the oom issue in child thread to terminate the application.

![image](https://user-images.githubusercontent.com/11972570/58541623-7b490400-822e-11e9-899f-d88cf7bf45fe.png)

## How was this patch tested?
Manual test in Q23a of TPC-DS
