### PR TITLE
Workaround to fix oom issue when building hash table in spark2.4.1

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/broadcastMode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/broadcastMode.scala
@@ -26,7 +26,8 @@ import org.apache.spark.sql.catalyst.InternalRow
 trait BroadcastMode {
   def transform(rows: Array[InternalRow]): Any
 
-  def transform(rows: Iterator[InternalRow], sizeHint: Option[Long]): Any
+  def transform(rows: Iterator[InternalRow], sizeHint: Option[Long],
+      estimatedPageSize: Int = 0): Any
 
   def canonicalized: BroadcastMode
 }
@@ -40,7 +41,7 @@ case object IdentityBroadcastMode extends BroadcastMode {
 
   override def transform(
       rows: Iterator[InternalRow],
-      sizeHint: Option[Long]): Array[InternalRow] = rows.toArray
+      sizeHint: Option[Long], estimatedPageSize: Int = 0): Array[InternalRow] = rows.toArray
 
   override def canonicalized: BroadcastMode = this
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -76,7 +76,7 @@ case class BroadcastExchangeExec(
         try {
           val beforeCollect = System.nanoTime()
           // Use executeCollect/executeCollectIterator to avoid conversion to Scala types
-          val (numRows, input) = child.executeCollectIterator()
+          val (numRows, input, estimatedPageSize) = child.executeCollectIterator()
           if (numRows >= 512000000) {
             throw new SparkException(
               s"Cannot broadcast the table with more than 512 millions rows: $numRows rows")
@@ -86,7 +86,7 @@ case class BroadcastExchangeExec(
           longMetric("collectTime") += (beforeBuild - beforeCollect) / 1000000
 
           // Construct the relation.
-          val relation = mode.transform(input, Some(numRows))
+          val relation = mode.transform(input, Some(numRows), estimatedPageSize)
 
           val dataSize = relation match {
             case map: HashedRelation =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/BroadcastExchangeExec.scala
@@ -85,6 +85,10 @@ case class BroadcastExchangeExec(
           val beforeBuild = System.nanoTime()
           longMetric("collectTime") += (beforeBuild - beforeCollect) / 1000000
 
+          // Call the GC method to free more available memory
+          // and then prevent the oom issue when build the hash table
+          System.gc()
+
           // Construct the relation.
           val relation = mode.transform(input, Some(numRows), estimatedPageSize)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
After investigation in [PR#91](https://github.com/Intel-bigdata/spark-adaptive/pull/91), we found the `page `and `array `object in `LongToUnsafeRowMap `class can occupy large memory when trigger related grow operator. This PR can reduce the large memory usage for `page `and `array `object. For the `page `object, we estimate the real size before the init method and then prevent the grow operator. For the `array `object, currently we call the GC API to free more available memory before building hash table and we are also trying to expand the initial array size and the load factor to prevent the grow operator.

## How was this patch tested?
add later