### PR TITLE
Fix additional exchange added when handling skewed join

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala
@@ -49,13 +49,23 @@ abstract class QueryStageInput extends LeafExecNode {
     }
   }
 
-  override def outputPartitioning: Partitioning = childStage.outputPartitioning match {
-    case h: HashPartitioning => h.copy(expressions = h.expressions.map(updateAttr))
-    case other => other
+  override def outputPartitioning: Partitioning = {
+    if (childStage.output.equals(output)) {
+      childStage.outputPartitioning
+    } else {
+      childStage.outputPartitioning match {
+        case e: Expression => updateAttr(e).asInstanceOf[Partitioning]
+        case other => other
+      }
+    }
   }
 
   override def outputOrdering: Seq[SortOrder] = {
-    childStage.outputOrdering.map(updateAttr(_).asInstanceOf[SortOrder])
+    if (childStage.output.equals(output)) {
+      childStage.outputOrdering
+    } else {
+      childStage.outputOrdering.map(updateAttr(_).asInstanceOf[SortOrder])
+    }
   }
 
   override def computeStats(): Statistics = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala
@@ -88,9 +88,11 @@ case class ShuffleQueryStageInput(
     var partitionEndIndices: Option[Array[Int]] = None)
   extends QueryStageInput {
 
-  override def outputPartitioning: Partitioning = partitionStartIndices.map {
-    indices => UnknownPartitioning(indices.length)
-  }.getOrElse(super.outputPartitioning)
+  override def outputPartitioning: Partitioning = partitionStartIndices match {
+    case Some(indices) => UnknownPartitioning(partitionStartIndices.get.length)
+    case None if isLocalShuffle => UnknownPartitioning(1)
+    case _ => super.outputPartitioning
+  }
 
   override def doExecute(): RDD[InternalRow] = {
     val childRDD = childStage.execute().asInstanceOf[ShuffledRowRDD]

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/QueryStageSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/QueryStageSuite.scala
@@ -331,6 +331,74 @@ class QueryStageSuite extends SparkFunSuite with BeforeAndAfterAll {
     }
   }
 
+  test("One of two sort merge leftSemi joins to broadcast join") {
+    // t1 is smaller than spark.sql.adaptiveBroadcastJoinThreshold
+    // t2 and t3 are greater than spark.sql.adaptiveBroadcastJoinThreshold
+    // Join1 changed to broadcast join.
+    //
+    //              Join2
+    //              /   \
+    //          Join1   Ex (Exchange)
+    //          /   \    \
+    //        Ex    Ex   t3
+    //       /       \
+    //      t1       t2
+    val spark = defaultSparkSession
+    spark.conf.set(SQLConf.ADAPTIVE_EXECUTION_ALLOW_ADDITIONAL_SHUFFLE.key, "true")
+    withSparkSession(spark) { spark: SparkSession =>
+      val df1 =
+        spark
+          .range(0, 1000, 1, numInputPartitions)
+          .selectExpr("id % 500 as key1", "id as value1")
+      val df2 =
+        spark
+          .range(0, 1000, 1, numInputPartitions)
+          .selectExpr("id % 500 as key2", "id as value2")
+      val df3 =
+        spark
+          .range(0, 1500, 1, numInputPartitions)
+          .selectExpr("id % 500 as key3", "id as value3")
+
+      val join =
+        df1
+          .join(df2, col("key1") === col("key2"), "leftSemi")
+          .join(df3, col("key1") === col("key3"), "leftSemi")
+          .select(col("key1"), col("value1"))
+
+      // Before Execution, there is two SortMergeJoins
+      val smjBeforeExecution = join.queryExecution.executedPlan.collect {
+        case smj: SortMergeJoinExec => smj
+      }
+      assert(smjBeforeExecution.length === 2)
+
+      // Check the answer.
+      val expectedAnswer =
+        spark
+          .range(0, 1000)
+          .selectExpr("id % 500 as key", "id as value")
+      checkAnswer(
+        join,
+        expectedAnswer.collect())
+
+      // During execution, one SortMergeJoin is changed to BroadcastHashJoin
+      val smjAfterExecution = join.queryExecution.executedPlan.collect {
+        case smj: SortMergeJoinExec => smj
+      }
+      assert(smjAfterExecution.length === 1)
+
+      val numBhjAfterExecution = join.queryExecution.executedPlan.collect {
+        case bhj: BroadcastHashJoinExec => bhj
+      }.length
+      assert(numBhjAfterExecution === 1)
+
+      val queryStageInputs = join.queryExecution.executedPlan.collect {
+        case q: QueryStageInput => q
+      }
+      assert(queryStageInputs.length === 3)
+    }
+  }
+
+
   test("Reuse QueryStage in adaptive execution") {
     withSparkSession(defaultSparkSession) { spark: SparkSession =>
       val df = spark.range(0, 1000, 1, numInputPartitions).toDF()


### PR DESCRIPTION
## What changes were proposed in this pull request?
When running following test:
![image](https://user-images.githubusercontent.com/5210402/58934341-be5e2680-879c-11e9-9849-e9cfaffd6cfc.png)
Following exception will occur:
Can't zip RDDs with unequal numbers of partitions: List(5, 1)
java.lang.IllegalArgumentException: Can't zip RDDs with unequal numbers of partitions: List(5, 1)
	at org.apache.spark.rdd.ZippedPartitionsBaseRDD.getPartitions(ZippedPartitionsRDD.scala:57)
	at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:253)
	at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:251)
	at scala.Option.getOrElse(Option.scala:121)
	at org.apache.spark.rdd.RDD.partitions(RDD.scala:251)
	at org.apache.spark.rdd.MapPartitionsRDD.getPartitions(MapPartitionsRDD.scala:46)
	at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:253)
	at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:251)
	at scala.Option.getOrElse(Option.scala:121)
	at org.apache.spark.rdd.RDD.partitions(RDD.scala:251)
The plan after handling skewed join :
![image](https://user-images.githubusercontent.com/5210402/58934459-1f85fa00-879d-11e9-8c90-6ca6b9cdcf11.png)
[Because the Joins are changed(1 smj => 1+5 smj), we need apply EnsureRequirements rule](https://github.com/Intel-bigdata/spark-adaptive/blob/branch-0.6-spark-2.3.2/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala#L109)
After applying EnsureRequirements, the new sort and exchange are be added for the case when expression hash partitioning:
![image](https://user-images.githubusercontent.com/5210402/58934968-9243a500-879e-11e9-8182-40a7e911e2a6.png)
 but QueryStage and QueryStageInput will not be inserted for new added Exchange, so it will not be considered by determining reducer number, that will lead to SortMergeJoin’s children can’t satisfy their output distribution requirements.

Why new sort and exchange are be added?
The output distribution requirements:
![image](https://user-images.githubusercontent.com/5210402/58935899-1303a080-87a1-11e9-9b02-8ab8acce9604.png)
The outputPartitioning of child:
![image](https://user-images.githubusercontent.com/5210402/58935975-3fb7b800-87a1-11e9-8769-151a197f4c99.png)
The canonicalized is null in child's outputPartitioning. Because after [updating the attribute ids in outputPartitioning and outputOrdering](https://github.com/Intel-bigdata/spark-adaptive/blob/branch-0.6-spark-2.3.2/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala#L48), the canonicalized changes to null. This patch will not update the attribute when the outputs are the same.

## How was this patch tested?
Add new unit test.
