### PR TITLE
Fix additional exchange added when handling skewed join

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala
@@ -49,13 +49,23 @@ abstract class QueryStageInput extends LeafExecNode {
     }
   }
 
-  override def outputPartitioning: Partitioning = childStage.outputPartitioning match {
-    case h: HashPartitioning => h.copy(expressions = h.expressions.map(updateAttr))
-    case other => other
+  override def outputPartitioning: Partitioning = {
+    if (childStage.output.equals(output)) {
+      childStage.outputPartitioning
+    } else {
+      childStage.outputPartitioning match {
+        case e: Expression => updateAttr(e).asInstanceOf[Partitioning]
+        case other => other
+      }
+    }
   }
 
   override def outputOrdering: Seq[SortOrder] = {
-    childStage.outputOrdering.map(updateAttr(_).asInstanceOf[SortOrder])
+    if (childStage.output.equals(output)) {
+      childStage.outputOrdering
+    } else {
+      childStage.outputOrdering.map(updateAttr(_).asInstanceOf[SortOrder])
+    }
   }
 
   override def computeStats(): Statistics = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala
@@ -50,23 +50,13 @@ abstract class QueryStageInput extends LeafExecNode {
     e.canonicalized
   }
 
-  override def outputPartitioning: Partitioning = {
-    if (childStage.output.equals(output)) {
-      childStage.outputPartitioning
-    } else {
-      childStage.outputPartitioning match {
-        case e: Expression => updateAttr(e).asInstanceOf[Partitioning]
-        case other => other
-      }
-    }
+  override def outputPartitioning: Partitioning = childStage.outputPartitioning match {
+    case e: Expression => updateAttr(e).asInstanceOf[Partitioning]
+    case other => other
   }
 
   override def outputOrdering: Seq[SortOrder] = {
-    if (childStage.output.equals(output)) {
-      childStage.outputOrdering
-    } else {
-      childStage.outputOrdering.map(updateAttr(_).asInstanceOf[SortOrder])
-    }
+    childStage.outputOrdering.map(updateAttr(_).asInstanceOf[SortOrder])
   }
 
   override def computeStats(): Statistics = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala
@@ -45,9 +45,9 @@ abstract class QueryStageInput extends LeafExecNode {
   private lazy val updateAttr: Expression => Expression = {
     val originalAttrToNewAttr = AttributeMap(childStage.output.zip(output))
     e => e.transform {
-      case attr: Attribute => originalAttrToNewAttr.getOrElse(attr, attr)
+      case attr: Attribute =>
+        originalAttrToNewAttr.getOrElse(attr, attr).withQualifier(attr.qualifier)
     }
-    e.canonicalized
   }
 
   override def outputPartitioning: Partitioning = childStage.outputPartitioning match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala
@@ -47,6 +47,7 @@ abstract class QueryStageInput extends LeafExecNode {
     e => e.transform {
       case attr: Attribute => originalAttrToNewAttr.getOrElse(attr, attr)
     }
+    e.canonicalized
   }
 
   override def outputPartitioning: Partitioning = {


### PR DESCRIPTION
## What changes were proposed in this pull request?
When running following test:
![image](https://user-images.githubusercontent.com/5210402/58937705-c79fc100-87a5-11e9-8838-f8c7ace77ae9.png)
Following exception will occur:
Can't zip RDDs with unequal numbers of partitions: List(5, 1)
java.lang.IllegalArgumentException: Can't zip RDDs with unequal numbers of partitions: List(5, 1)
at org.apache.spark.rdd.ZippedPartitionsBaseRDD.getPartitions(ZippedPartitionsRDD.scala:57)
at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:253)
at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:251)
at scala.Option.getOrElse(Option.scala:121)
at org.apache.spark.rdd.RDD.partitions(RDD.scala:251)
at org.apache.spark.rdd.MapPartitionsRDD.getPartitions(MapPartitionsRDD.scala:46)
at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:253)
at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:251)
at scala.Option.getOrElse(Option.scala:121)
at org.apache.spark.rdd.RDD.partitions(RDD.scala:251)

The plan after handling skewed join :
![image](https://user-images.githubusercontent.com/5210402/58937738-d9816400-87a5-11e9-8109-ab8748eddf5a.png)
Because the Joins are changed(1 smj => 1+5 smj), we need [apply EnsureRequirements rule](https://github.com/Intel-bigdata/spark-adaptive/blob/branch-0.6-spark-2.3.2/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala#L109)
After applying EnsureRequirements, the new sort and exchange are be added for the case when expression hash partitioning:
![image](https://user-images.githubusercontent.com/5210402/58937795-033a8b00-87a6-11e9-868d-35b35e6b5158.png)
but QueryStage and QueryStageInput will not be inserted for new added Exchange, so it will not be considered by determining reducer number, that will lead to SortMergeJoin’s children can’t satisfy their output distribution requirements.

Why new sort and exchange are be added?
The output distribution requirements:
![image](https://user-images.githubusercontent.com/5210402/58937830-2107f000-87a6-11e9-9899-b7382739b8b8.png)
The outputPartitioning of child:
![image](https://user-images.githubusercontent.com/5210402/58937846-2b29ee80-87a6-11e9-8c53-2e830bbafb6e.png)
The canonicalized is null in child's outputPartitioning. Because after [updating the attribute ids in outputPartitioning and outputOrdering](https://github.com/Intel-bigdata/spark-adaptive/blob/branch-0.6-spark-2.3.2/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageInput.scala#L48), the canonicalized changes to null. This patch will not update the attribute when the outputs are the same.

## How was this patch tested?
Add new unit test.
