### PR TITLE
pass all job properties to thread pool in QueryStage.executechildStag…

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution
 
+import java.util.Properties
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
@@ -100,20 +101,15 @@ object SQLExecution {
     }
   }
 
-  def withExecutionIdAndJobDesc[T](
+  def withJobProperties[T](
       sc: SparkContext,
-      executionId: String,
-      jobDesc: String)(body: => T): T = {
-    val oldExecutionId = sc.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-    val oldJobDesc = sc.getLocalProperty(SparkContext.SPARK_JOB_DESCRIPTION)
-
+      properties: Properties)(body: => T): T = {
     try {
-      sc.setLocalProperty(SQLExecution.EXECUTION_ID_KEY, executionId)
-      sc.setLocalProperty(SparkContext.SPARK_JOB_DESCRIPTION, jobDesc)
+      sc.setLocalProperties(properties)
       body
     } finally {
-      sc.setLocalProperty(SQLExecution.EXECUTION_ID_KEY, oldExecutionId)
-      sc.setLocalProperty(SparkContext.SPARK_JOB_DESCRIPTION, oldJobDesc)
+      sc.setLocalProperties(properties)
     }
+
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/JobGroupIdSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/JobGroupIdSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.language.existentials
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.status.JobDataWrapper
+
+class JobGroupIdSuite extends QueryTest with AEContext {
+
+  test("adaptive execution should run with right Job Group") {
+    val isFinished = new AtomicInteger(0)
+    class Worker(id: String, desc: String) extends Runnable {
+      override def run(): Unit = {
+        spark.sparkContext.setJobGroup(id, desc)
+        spark.sql("select 1 as key, 'a' as v1").createOrReplaceTempView("test")
+        spark.sql("select 1 as key, '2' as v2").createOrReplaceTempView("test2")
+        spark.sql("select * from test join test2 on test.key = test2.key").show
+        isFinished.incrementAndGet()
+      }
+    }
+    val executor = Executors.newFixedThreadPool(1)
+    val w1 = new Worker("1", "job group one")
+    executor.submit(w1)
+    val w2 = new Worker("2", "job group tow")
+    executor.submit(w2)
+
+    // waiting for job finish.
+    while (isFinished.get() < 2) {
+      Thread.sleep(1000)
+    }
+    val jobStart = spark.sparkContext.statusStore.store.read(classOf[JobDataWrapper], 2)
+    assert(jobStart.info.jobGroup == Some("2"))
+  }
+}
+
+trait AEContext extends SharedSQLContext {
+  override def sparkConf: SparkConf = {
+    val conf = super.sparkConf
+    conf.set("spark.sql.adaptive.enabled", "true")
+    conf.set("spark.sql.adaptive.join.enabled", "true")
+    conf.set("spark.sql.adaptive.skewedJoin.enabled", "true")
+    conf.set("spark.ui.enabled", "true")
+    conf.set("spark.sql.crossJoin.enabled", "true")
+    conf
+  }
+
+}
+


### PR DESCRIPTION
pass all job properties to thread pool in QueryStage.executechildStage() 

fix #95 