### PR TITLE
Change the condition of converting smj to bhj from compressed size to row counts

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -271,6 +271,13 @@ object SQLConf {
     .longConf
     .createOptional
 
+  val ADAPTIVE_BROADCASTJOIN_ROW_COUNT_THRESHOLD =
+    buildConf("spark.sql.adaptiveBroadcastJoinRowCountThreshold")
+      .doc("Configures the row counts of a table that will be" +
+        " broadcast to all worker nodes when performing a join in adaptive execution mode")
+      .longConf
+      .createWithDefault(100000000L) // 1 million
+
   val ADAPTIVE_EXECUTION_ALLOW_ADDITIONAL_SHUFFLE =
     buildConf("spark.sql.adaptive.allowAdditionalShuffle")
       .doc("When true, additional shuffles are allowed during plan optimizations in adaptive " +
@@ -1721,6 +1728,9 @@ class SQLConf extends Serializable with Logging {
 
   def adaptiveBroadcastJoinThreshold: Long =
     getConf(ADAPTIVE_BROADCASTJOIN_THRESHOLD).getOrElse(autoBroadcastJoinThreshold)
+
+  def adaptiveBroadcastJoinRowCountThreshold: Long =
+    getConf(ADAPTIVE_BROADCASTJOIN_ROW_COUNT_THRESHOLD)
 
   def adaptiveAllowAdditionShuffle: Boolean = getConf(ADAPTIVE_EXECUTION_ALLOW_ADDITIONAL_SHUFFLE)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
In Tencent cloud environment, when enable ae, it will convert smj to bhj in runtime based on the compressed size of small table with 16M. However, when building hash table, the decompressed size of small table can be up to 2GB and the row counts can be 134485048, which cause the OOM. In order to resolve this issue, this PR change the condition from compressed size to row counts when converting smj to bhj.

## How was this patch tested?
Existing tests.