### PR TITLE
Fix the hang issue in spark2.3.2 version

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.plans.physical.{HashPartitioning, Partition
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.execution.ui.SparkListenerSQLAdaptiveExecutionUpdate
-import org.apache.spark.util.ThreadUtils
+import org.apache.spark.util.{SparkUncaughtExceptionHandler, ThreadUtils}
 
 /**
  * In adaptive execution mode, an execution plan is divided into multiple QueryStages. Each
@@ -97,6 +97,11 @@ abstract class QueryStage extends UnaryExecNode {
     if (prepared) {
       return
     }
+
+    // set the uncaughtExceptionHandler to catch the exception of child thread in the
+    // parent thread and then prevent the hang issue
+    Thread.setDefaultUncaughtExceptionHandler(new SparkUncaughtExceptionHandler())
+
     // 1. Execute childStages
     executeChildStages()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Back port [PR#91](https://github.com/Intel-bigdata/spark-adaptive/pull/91) to spark2.3.2.

## How was this patch tested?
manual q23a.sql in cluster mode
