### PR TITLE
Add switchoff for Continuous shuffle block batch fetch

### DIFF
--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -283,7 +283,7 @@ private[spark] abstract class MapOutputTracker(conf: SparkConf) extends Logging 
   }
 
   protected def supportsContinuousBlockBatchFetch(serializerRelocatable: Boolean): Boolean = {
-    if (!serializerRelocatable) {
+    if (!serializerRelocatable || !conf.get(SHUFFLE_CONTINUOUS_BLOCK_BATCH_FETCH_ENABLED)) {
       false
     } else {
       if (!conf.getBoolean("spark.shuffle.compress", true)) {

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -545,4 +545,11 @@ package object config {
       "threshold. Otherwise CompressedMapStatus is used.")
     .intConf
     .createWithDefault(2000)
+
+  private[spark] val SHUFFLE_CONTINUOUS_BLOCK_BATCH_FETCH_ENABLED =
+    ConfigBuilder("spark.shuffle.continuousBlockBatchFetch.enabled")
+      .doc("When enabled, the adaptive execution engine will try to fetch continuous block " +
+        "in batch.")
+      .booleanConf
+      .createWithDefault(false)
 }


### PR DESCRIPTION

## What changes were proposed in this pull request?

In our production cluster, we encountered data incorrect issues when using spark-ae. After carefully looking into the code and debugging, we finally find out that this issue is caused by external shuffle service configuration.
Currently, spark-ae force use continuous shuffle block batch fetch, however, in many cases, external shuffle service is enabled, but the external shuffle service jars was not upgraded to spark-ae or users should be conservative  to do upgrading for a large cluster. So we'd better provide an option for this feature.

This PR add an option for continuous shuffle block batch fetch feature, and set it to false by default to avoid such data incorrect issues for new users when they are not aware that the external shuffle service should also be upgraded.

## How was this patch tested?

UT
