### PR TITLE
backport PR#69 to spark 2.3.2

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/statsEstimation/SizeInBytesOnlyStatsPlanVisitor.scala
@@ -110,7 +110,8 @@ object SizeInBytesOnlyStatsPlanVisitor extends SparkPlanVisitor[Statistics] {
 
   override def visitShuffleQueryStage(p: ShuffleQueryStage): Statistics = {
     if (p.mapOutputStatistics != null) {
-      val sizeInBytes = p.mapOutputStatistics.bytesByPartitionId.sum
+      val childDataSize = p.child.metrics.get("dataSize").map(_.value).getOrElse(0L)
+      val sizeInBytes = p.mapOutputStatistics.bytesByPartitionId.sum.max(childDataSize)
       val bytesByPartitionId = p.mapOutputStatistics.bytesByPartitionId
       if (p.mapOutputStatistics.recordsByPartitionId.nonEmpty) {
         val record = p.mapOutputStatistics.recordsByPartitionId.sum

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/QueryStageSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/QueryStageSuite.scala
@@ -55,7 +55,7 @@ class QueryStageSuite extends SparkFunSuite with BeforeAndAfterAll {
       .config(config.SHUFFLE_STATISTICS_VERBOSE.key, "true")
       .config(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
       .config(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
-      .config(SQLConf.ADAPTIVE_BROADCASTJOIN_THRESHOLD.key, "12000")
+      .config(SQLConf.ADAPTIVE_BROADCASTJOIN_THRESHOLD.key, "16000")
       .getOrCreate()
     spark
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
back port [PR#69](https://github.com/Intel-bigdata/spark-adaptive/pull/69) to branch-0.6-spark-2.3.2.
## How was this patch tested?
existing ut
