### PR TITLE
Optimize the sort merge join to shuffle hash join when can not convert to broad cast hash join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -238,6 +238,19 @@ object SQLConf {
     .longConf
     .createOptional
 
+  val ADAPTIVE_EXECUTION_HASHJOIN_ENABLED = buildConf("spark.sql.adaptive.hashJoin.enabled")
+    .doc("When true and adaptive execution is enabled, hash join strategy is determined at " +
+      "runtime.")
+    .booleanConf
+    .createWithDefault(false)
+
+  val ADAPTIVE_EXECUTION_HASHJOIN_FACTOR = buildConf("spark.sql.adaptive.hashjoinFactor")
+      .doc("he cost to build hash map is higher than sorting," +
+        " we should only build hash map on a table that is much smaller" +
+        " than other one. It is the smaller times.")
+      .intConf
+      .createWithDefault(3)
+
   val ADAPTIVE_EXECUTION_ALLOW_ADDITIONAL_SHUFFLE =
     buildConf("spark.sql.adaptive.allowAdditionalShuffle")
       .doc("When true, additional shuffles are allowed during plan optimizations in adaptive " +
@@ -1368,6 +1381,10 @@ class SQLConf extends Serializable with Logging {
 
   def adaptiveBroadcastJoinThreshold: Long =
     getConf(ADAPTIVE_BROADCASTJOIN_THRESHOLD).getOrElse(autoBroadcastJoinThreshold)
+
+  def adaptiveHashJoinEnabled: Boolean = getConf(ADAPTIVE_EXECUTION_HASHJOIN_ENABLED)
+
+  def adaptiveHashJoinFactor: Int = getConf(ADAPTIVE_EXECUTION_HASHJOIN_FACTOR)
 
   def adaptiveAllowAdditionShuffle: Boolean = getConf(ADAPTIVE_EXECUTION_ALLOW_ADDITIONAL_SHUFFLE)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSMJtoSHJ.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSMJtoSHJ.scala
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.adaptive
+
+import org.apache.spark.sql.catalyst.expressions.RowOrdering
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{SortExec, SparkPlan}
+import org.apache.spark.sql.execution.exchange.{EnsureRequirements, ShuffleExchangeExec}
+import org.apache.spark.sql.execution.joins.{BuildLeft, BuildRight, ShuffledHashJoinExec, SortMergeJoinExec}
+import org.apache.spark.sql.internal.SQLConf
+
+// optimize the sort merge join to shuffle hash join
+case class OptimizeSMJtoSHJ(conf: SQLConf) extends Rule[SparkPlan] {
+  /**
+   * Returns whether plan a is much smaller (3X) than plan b.
+   *
+   * The cost to build hash map is higher than sorting, we should only build hash map on a table
+   * that is much smaller than other one. Since we does not have the statistic for number of rows,
+   * use the size of bytes here as estimation.
+   */
+  private def muchSmaller(a: SparkPlan, b: SparkPlan): Boolean = {
+    a.stats.sizeInBytes * conf.adaptiveHashJoinFactor <= b.stats.sizeInBytes
+  }
+
+  /**
+   * Matches a plan whose single partition should be small enough to build a hash table.
+   *
+   * Note: this assume that the number of partition is fixed, requires additional work if it's
+   * dynamic.
+   */
+  private def canBuildLocalHashMap(plan: SparkPlan, initialPlan: SparkPlan): Boolean = {
+    plan.stats.sizeInBytes < conf.adaptiveBroadcastJoinThreshold *
+      (EnsureRequirements(conf).defaultNumPreShufflePartitions(initialPlan))
+  }
+
+  private def canBuildRight(joinType: JoinType): Boolean = joinType match {
+    case _: InnerLike | LeftOuter | LeftSemi | LeftAnti => true
+    case j: ExistenceJoin => true
+    case _ => false
+  }
+
+  private def canBuildLeft(joinType: JoinType): Boolean = joinType match {
+    case _: InnerLike | RightOuter => true
+    case _ => false
+  }
+
+  private def removeSort(plan: SparkPlan): SparkPlan = {
+    plan match {
+      case s: SortExec => s.child
+      case p: SparkPlan => p
+    }
+  }
+
+  private def optimizeSortMergeJoin(
+      smj: SortMergeJoinExec,
+      queryStage: QueryStage,
+      initialPlan: SparkPlan): SparkPlan = {
+    smj match {
+      case SortMergeJoinExec(leftKeys, rightKeys, joinType, condition, left, right) =>
+        val hashJoinBuildSide = if (canBuildRight(joinType)
+          && (muchSmaller(removeSort(right), removeSort(left))
+          && canBuildLocalHashMap(removeSort(right), initialPlan))
+          || !RowOrdering.isOrderable(leftKeys)) {
+          Some(BuildRight)
+        } else if (canBuildLeft(joinType)
+          && (muchSmaller(removeSort(left), removeSort(right))
+          && canBuildLocalHashMap(removeSort(left), initialPlan))
+          || !RowOrdering.isOrderable(rightKeys)) {
+          Some(BuildLeft)
+        } else {
+          None
+        }
+
+        hashJoinBuildSide.map { buildSide =>
+          val hashJoin = ShuffledHashJoinExec(
+            leftKeys,
+            rightKeys,
+            joinType,
+            buildSide,
+            condition,
+            removeSort(left),
+            removeSort(right))
+          val newChild = queryStage.child.transformDown {
+            case s: SortMergeJoinExec if s.fastEquals(smj) => hashJoin
+          }
+
+          // Apply EnsureRequirement rule to check if any new Exchange will be added.
+          // If new exchange added, disable to convert the smj to shj.
+          val afterEnsureRequirements = EnsureRequirements(conf).apply(newChild)
+          val numExchanges = afterEnsureRequirements.collect {
+            case e: ShuffleExchangeExec => e
+          }.length
+          val topShuffleCheck = queryStage match {
+            case _: ShuffleQueryStage => afterEnsureRequirements.isInstanceOf[ShuffleExchangeExec]
+            case _ => true
+          }
+          val noAdditionalShuffle = (numExchanges == 0) ||
+            (queryStage.isInstanceOf[ShuffleQueryStage] && numExchanges <= 1)
+
+          if (topShuffleCheck && noAdditionalShuffle) {
+            queryStage.child = newChild
+            hashJoin
+          } else {
+            logWarning("Join optimization is not applied due to additional shuffles will be " +
+              "introduced.")
+            smj
+          }
+        }.getOrElse(smj)
+    }
+  }
+
+  private def optimizeJoin(
+      operator: SparkPlan,
+      queryStage: QueryStage,
+      initialPlan: SparkPlan): SparkPlan = {
+    operator match {
+      case smj: SortMergeJoinExec =>
+        val op = optimizeSortMergeJoin(smj, queryStage, initialPlan)
+        val optimizedChildren = op.children.map(optimizeJoin(_, queryStage, initialPlan))
+        op.withNewChildren(optimizedChildren)
+      case op =>
+        val optimizedChildren = op.children.map(optimizeJoin(_, queryStage, initialPlan))
+        op.withNewChildren(optimizedChildren)
+    }
+  }
+
+  def apply(plan: SparkPlan): SparkPlan = {
+    if (!conf.adaptiveHashJoinEnabled) {
+      plan
+    } else {
+      plan match {
+        case queryStage: QueryStage =>
+          val optimizedPlan = optimizeJoin(queryStage.child, queryStage, plan)
+          queryStage.child = optimizedPlan
+          queryStage
+        case _ => plan
+      }
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStage.scala
@@ -108,6 +108,7 @@ abstract class QueryStage extends UnaryExecNode {
     // It is possible to optimize this stage's plan here based on the child stages' statistics.
     val oldChild = child
     OptimizeJoin(conf).apply(this)
+    OptimizeSMJtoSHJ(conf).apply(this)
     HandleSkewedJoin(conf).apply(this)
     // If the Joins are changed, we need apply EnsureRequirements rule to add BroadcastExchange.
     if (!oldChild.fastEquals(child)) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.internal.SQLConf
  * the input partition ordering requirements are met.
  */
 case class EnsureRequirements(conf: SQLConf) extends Rule[SparkPlan] {
-  private def defaultNumPreShufflePartitions(plan: SparkPlan): Int =
+  def defaultNumPreShufflePartitions(plan: SparkPlan): Int =
     if (conf.adaptiveExecutionEnabled) {
       if (conf.adaptiveAutoCalculateInitialPartitionNum) {
         autoCalculateInitialPartitionNum(plan)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/QueryStageSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/QueryStageSuite.scala
@@ -450,6 +450,147 @@ class QueryStageSuite extends SparkFunSuite with BeforeAndAfterAll {
     }
   }
 
+  test("one of two sort merge joins to shuffled hash joins") {
+    // Every shuffle partition of t2 and t3 is smaller than
+    // the spark.sql.adaptiveHashJoinThreshold
+    // Both Join1 and Join2 can change to shuffled hash join.
+    // But when Join1 is changed to shuffled hash join,
+    // it will introduce additional exchange in Join1 and Join2
+    // because the exprId is not same.
+    //
+    //              Join2
+    //              /   \
+    //          Join1   Ex (Exchange)
+    //          /   \    \
+    //        Ex    Ex   t3
+    //       /       \
+    //      t1       t2
+    val spark = defaultSparkSession
+    spark.conf.set(SQLConf.ADAPTIVE_EXECUTION_HASHJOIN_ENABLED.key, "true")
+    withSparkSession(spark) { spark: SparkSession =>
+      val df1 =
+        spark
+          .range(0, 2000, 1, numInputPartitions)
+          .selectExpr("id % 1000 as key1", "id as value1")
+      val df2 =
+        spark
+          .range(0, 2000, 1, numInputPartitions)
+          .selectExpr("id % 1000 as key2", "id as value2")
+      val df3 =
+        spark
+          .range(0, 2000, 1, numInputPartitions)
+          .selectExpr("id % 1000 as key3", "id as value3")
+
+      val join =
+        df1
+          .join(df2, col("key1") === col("key2"))
+          .join(df3, col("key2") === col("key3"))
+          .select(col("key3"), col("value1"))
+
+      // Before Execution, there is two SortMergeJoins
+      val smjBeforeExecution = join.queryExecution.executedPlan.collect {
+        case smj: SortMergeJoinExec => smj
+      }
+      assert(smjBeforeExecution.length === 2)
+
+      // Check the answer.
+      val partResult =
+      spark
+        .range(0, 2000)
+        .selectExpr("id % 1000 as key", "id as value")
+        .union(spark.range(0, 2000).selectExpr("id % 1000 as key", "id as value"))
+      val expectedAnswer = partResult.union(partResult)
+      checkAnswer(
+        join,
+        expectedAnswer.collect())
+
+      // During execution, 1 SortMergeJoin are changed to ShuffledHashJoin
+      val smjAfterExecution = join.queryExecution.executedPlan.collect {
+        case smj: SortMergeJoinExec => smj
+      }
+      assert(smjAfterExecution.length === 1)
+
+      val numShjAfterExecution = join.queryExecution.executedPlan.collect {
+        case smj: ShuffledHashJoinExec => smj
+      }.length
+      assert(numShjAfterExecution === 1)
+
+      val queryStageInputs = join.queryExecution.executedPlan.collect {
+        case q: QueryStageInput => q
+      }
+      assert(queryStageInputs.length === 3)
+    }
+  }
+
+  test("2 sort merge joins to shuffled hash joins") {
+    // Every shuffle partition of t2 and t3 is smaller than
+    // the spark.sql.adaptiveHashJoinThreshold
+    // Both Join1 and Join2 can change to shuffled hash join.
+    //
+    //              Join2
+    //              /   \
+    //          Join1   Ex (Exchange)
+    //          /   \    \
+    //        Ex    Ex   t3
+    //       /       \
+    //      t1       t2
+    val spark = defaultSparkSession
+    spark.conf.set(SQLConf.ADAPTIVE_EXECUTION_HASHJOIN_ENABLED.key, "true")
+    withSparkSession(spark) { spark: SparkSession =>
+      val df1 =
+        spark
+          .range(0, 2000, 1, numInputPartitions)
+          .selectExpr("id % 500 as key1", "id as value1")
+      val df2 =
+        spark
+          .range(0, 500, 1, numInputPartitions)
+          .selectExpr("id % 500 as key2", "id as value2")
+      val df3 =
+        spark
+          .range(0, 2000, 1, numInputPartitions)
+          .selectExpr("id % 500 as key3", "id as value3")
+
+      val join =
+        df1
+          .join(df2, col("key1") === col("key2"))
+          .join(df3, col("key2") === col("key3"))
+          .select(col("key3"), col("value1"))
+
+      // Before Execution, there is two SortMergeJoins
+      val smjBeforeExecution = join.queryExecution.executedPlan.collect {
+        case smj: SortMergeJoinExec => smj
+      }
+      assert(smjBeforeExecution.length === 2)
+
+      // Check the answer.
+      val partResult =
+      spark
+        .range(0, 2000)
+        .selectExpr("id % 500 as key", "id as value")
+        .union(spark.range(0, 2000).selectExpr("id % 500 as key", "id as value"))
+      val expectedAnswer = partResult.union(partResult)
+      checkAnswer(
+        join,
+        expectedAnswer.collect())
+
+      // During execution, 1 SortMergeJoin are changed to ShuffledHashJoin
+      val smjAfterExecution = join.queryExecution.executedPlan.collect {
+        case smj: SortMergeJoinExec => smj
+      }
+      assert(smjAfterExecution.length === 1)
+
+      val numShjAfterExecution = join.queryExecution.executedPlan.collect {
+        case smj: ShuffledHashJoinExec => smj
+      }.length
+      assert(numShjAfterExecution === 1)
+
+      val queryStageInputs = join.queryExecution.executedPlan.collect {
+        case q: QueryStageInput => q
+      }
+      assert(queryStageInputs.length === 3)
+    }
+  }
+
   test("Reuse QueryStage in adaptive execution") {
     withSparkSession(defaultSparkSession) { spark: SparkSession =>
       val df = spark.range(0, 1000, 1, numInputPartitions).toDF()


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a new rule to change the sort merge join to shuffle hash join when sort merge join can not be converted to broad cast hash join.

## How was this patch tested?
Add unit test