### PR TITLE
remove stage barrier

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -545,4 +545,21 @@ package object config {
       "threshold. Otherwise CompressedMapStatus is used.")
     .intConf
     .createWithDefault(2000)
+
+  private[spark] val REMOVE_STAGE_BARRIER =
+    ConfigBuilder("spark.shuffle.removeStageBarrier")
+      .doc("to do")
+      .booleanConf
+      .createWithDefault(false)
+
+  private[spark] val REMOVE_STAGE_BARRIER_THRESHOLD =
+    ConfigBuilder("spark.shuffle.removeStageBarrier.threshold")
+      .doc("to do")
+      .intConf
+      .createWithDefault(90)
+  private[spark] val REMOVE_STAGE_BARRIER_FACTOR =
+    ConfigBuilder("spark.shuffle.removeStageBarrier.factor")
+      .doc("to do")
+      .intConf
+      .createWithDefault(1)
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -23,15 +23,13 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.annotation.tailrec
-import scala.collection.Map
-import scala.collection.mutable.{ArrayStack, HashMap, HashSet}
+import scala.collection.{Map, mutable}
+import scala.collection.mutable.{ArrayBuffer, ArrayStack, HashMap, HashSet}
 import scala.concurrent.duration._
 import scala.language.existentials
 import scala.language.postfixOps
 import scala.util.control.NonFatal
-
 import org.apache.commons.lang3.SerializationUtils
-
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.executor.TaskMetrics
@@ -161,6 +159,15 @@ class DAGScheduler(
   private[scheduler] val failedStages = new HashSet[Stage]
 
   private[scheduler] val activeJobs = new HashSet[ActiveJob]
+
+  val removeStageBarrier = SparkEnv.get.conf.getBoolean("spark.shuffle.removeStageBarrier", false)
+  val removeStageBarrierThreshold= SparkEnv.get.conf.getInt("spark.shuffle.removeStageBarrier.threshold",80)
+  val removeStageBarrierFactor= SparkEnv.get.conf.getInt("spark.shuffle.removeStageBarrier.factor",1)
+
+  if(removeStageBarrier){
+    logInfo("DAG remove stage barrier is on")
+  }
+
 
   /**
    * Contains the locations that each RDD's partitions are cached on.  This map's keys are RDD ids
@@ -1106,6 +1113,58 @@ class DAGScheduler(
     }
   }
 
+  // Select a waiting stage to pre-start
+  private def getPreStartableStage(stage: Stage): Option[Stage] = {
+    for (waitingStage <- waitingStages) {
+      if (!waitingStage.isInstanceOf[ResultStage]) {
+        val missingParents = getMissingParentStages(waitingStage)
+        if (missingParents.contains(stage)) {
+          val flag = missingParents.exists(parent => (waitingStages.contains(parent) || failedStages.contains(parent)
+            | getMissingParentStages(parent).size > 0 || parent.rdd.getStorageLevel != StorageLevel.NONE) ||
+            ((1 - parent.asInstanceOf[ShuffleMapStage].pendingPartitions.size / parent.numPartitions.toFloat) < removeStageBarrierThreshold / 100.0)
+          ||parent.findMissingPartitions().size * removeStageBarrierFactor > waitingStage.findMissingPartitions().size )
+          if (flag) {
+            logInfo("RSB: not all parent have completed in condition")
+            val FP = missingParents.filter(parent =>
+              ((1 - parent.asInstanceOf[ShuffleMapStage].pendingPartitions.size / parent.numPartitions.toFloat) < removeStageBarrierThreshold / 100.0))
+
+            FP.foreach(parent => logInfo("RSB: shuffle id  : " + parent.id + " ratio :" + (1 - parent.asInstanceOf[ShuffleMapStage].pendingPartitions.size / parent.numPartitions.toFloat)))
+            return None
+          } else {
+            logInfo("RSB: prepare preStart   " + waitingStage.id)
+            return Some(waitingStage)
+          }
+        }
+      }
+      else{
+        logInfo("RSB: is ResultStage can not preStart" + waitingStage.id)
+      }
+    }
+    None
+  }
+
+  private def maybePreStartWaitingStage(stage: Stage,shuffleId: Int,mapId: Int,status: MapStatus) {
+    if (removeStageBarrier && taskScheduler.isInstanceOf[TaskSchedulerImpl]) {
+      val backend = taskScheduler.asInstanceOf[TaskSchedulerImpl].backend
+      var numPendingTask:Int = 0
+      runningStages.foreach { stage =>
+        if(stage.isInstanceOf[ShuffleMapStage])
+          numPendingTask += stage.asInstanceOf[ShuffleMapStage].pendingPartitions.size
+      }
+      val numWaitingStage = waitingStages.size
+      if (numWaitingStage > 0 && backend.freeSlotAvail(numPendingTask)) {
+        for (preStartStage <- getPreStartableStage(stage)) {
+          if(backend.freeSlotAvail(numPendingTask)){
+            logInfo("RSB:Pre-start stage " + preStartStage.id)
+            waitingStages -= preStartStage
+            runningStages += preStartStage
+            submitMissingTasks(preStartStage, activeJobForStage(preStartStage).get)
+          }
+        }
+      }
+    }
+  }
+
   /**
    * Merge local values from a task into the corresponding accumulators previously registered
    * here on the driver.
@@ -1296,6 +1355,14 @@ class DAGScheduler(
                 submitWaitingChildStages(shuffleStage)
               }
             }
+
+              if(removeStageBarrier && !shuffleStage.isAvailable
+                &&runningStages.contains(shuffleStage)
+                && haveEnoughCompletion(shuffleStage)){
+                logInfo("shuffle id: " + shuffleStage.id + " shuffleStage.completed.ratio:" +
+                  (1-(shuffleStage.pendingPartitions.size.toFloat / shuffleStage.numPartitions)))
+                maybePreStartWaitingStage(stage,shuffleStage.shuffleDep.shuffleId,smt.partitionId,status)
+              }
         }
 
       case Resubmitted =>
@@ -1504,6 +1571,11 @@ class DAGScheduler(
       fileLost = fileLost,
       hostToUnregisterOutputs = None,
       maybeEpoch = None)
+  }
+
+  private def haveEnoughCompletion(shuffleStage: ShuffleMapStage): Boolean ={
+    (1-(shuffleStage.pendingPartitions.size.toFloat / shuffleStage.numPartitions)
+      > removeStageBarrierThreshold/100.0)
   }
 
   private def removeExecutorAndUnregisterOutputs(

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1156,9 +1156,8 @@ class DAGScheduler(
         for (preStartStage <- getPreStartableStage(stage)) {
           if(backend.freeSlotAvail(numPendingTask)){
             logInfo("RSB:Pre-start stage " + preStartStage.id)
-            waitingStages -= preStartStage
-            runningStages += preStartStage
             submitMissingTasks(preStartStage, activeJobForStage(preStartStage).get)
+            waitingStages -= preStartStage
           }
         }
       }
@@ -1356,7 +1355,7 @@ class DAGScheduler(
               }
             }
 
-              if(removeStageBarrier && !shuffleStage.isAvailable
+              if(removeStageBarrier && !shuffleStage.isAvailable && !shuffleStage.pendingPartitions.isEmpty
                 &&runningStages.contains(shuffleStage)
                 && haveEnoughCompletion(shuffleStage)){
                 logInfo("shuffle id: " + shuffleStage.id + " shuffleStage.completed.ratio:" +

--- a/core/src/main/scala/org/apache/spark/scheduler/SchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/SchedulerBackend.scala
@@ -45,6 +45,8 @@ private[spark] trait SchedulerBackend {
       reason: String): Unit =
     throw new UnsupportedOperationException
 
+  def freeSlotAvail(numTask: Int): Boolean = false
+
   def isReady(): Boolean = true
 
   /**

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -55,6 +55,14 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
   // is equal to at least this value, that is double between 0 and 1.
   private val _minRegisteredRatio =
     math.min(1, conf.getDouble("spark.scheduler.minRegisteredResourcesRatio", 0))
+
+  override def freeSlotAvail(numTask: Int): Boolean = {
+    val flag = numTask * scheduler.CPUS_PER_TASK < totalCoreCount.get()
+    if(flag) logInfo("have extra cpu resource")
+    else logInfo("not enough cpu resource ")
+    flag
+  }
+
   // Submit tasks after maxRegisteredWaitingTime milliseconds
   // if minRegisteredRatio has not yet been reached
   private val maxRegisteredWaitingTimeMs =

--- a/core/src/main/scala/org/apache/spark/storage/PartialBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/PartialBlockFetcherIterator.scala
@@ -1,0 +1,139 @@
+package org.apache.spark.storage
+import java.io.InputStream
+import org.apache.spark.{ SparkEnv, TaskContext}
+import org.apache.spark.internal.{Logging, config}
+import scala.collection.mutable.{ArrayBuffer, HashSet}
+import org.apache.spark.network.shuffle.ShuffleClient
+
+private[spark]
+class PartialBlockFetcherIterator(
+                                   context: TaskContext,
+                                   shuffleClient: ShuffleClient,
+                                   blockManager: BlockManager,
+                                   startPartition: Int,
+                                   endPartition: Int,
+                                   startMapId: Option[Int] = None,
+                                   endMapId: Option[Int] = None,
+                                   streamWrapper: (BlockId, InputStream) => InputStream,
+                                   shuffleId: Int
+                                 )
+  extends Iterator[(BlockId, InputStream)] with Logging {
+
+  private val mapOutputFetchInterval =
+    SparkEnv.get.conf.getInt("spark.reducer.mapOutput.fetchInterval", 1000)
+
+  private var iterator: Iterator[(BlockId, InputStream)] = null
+
+  // Track the map outputs we've delegated
+  private val delegatedStatuses = new HashSet[String]()
+
+  private var fetchTime: Int = 1
+
+  private var statuses: Seq[(BlockManagerId, Seq[(BlockId, Long)])] = null
+
+  private var notNullStatuses: Seq[(BlockManagerId, Seq[(BlockId, Long)])] = null
+
+  statuses = SparkEnv.get.mapOutputTracker.getUpdatedStatus(shuffleId, startPartition,endPartition,startMapId.getOrElse(-1),endMapId.getOrElse(-1))
+
+  initialize()
+
+  // Get the updated map output
+  private def updateStatuses() {
+    fetchTime += 1
+
+    statuses = SparkEnv.get.mapOutputTracker.getUpdatedStatus(shuffleId, startPartition,endPartition,startMapId.getOrElse(-1),endMapId.getOrElse(-1))
+
+  }
+
+
+  private def readyStatuses: Seq[(BlockManagerId, Seq[(BlockId, Long)])] = {
+    if(statuses == null)  statuses
+    else {
+      statuses.filter(_._1 != null)
+      statuses.foreach(x => x._2.filter(_._1 != null))
+      statuses
+    }
+  }
+  // Check if there's new map outputs available
+  private def newStatusesReady = {
+    if(readyStatuses == null || readyStatuses.size == 0) false
+    else hashExtraBlock(delegatedStatuses,readyStatuses)
+
+  }
+  //Check if there's new new block available
+  private def hashExtraBlock(delegatedStatuses: HashSet[String],
+                             readyStatuses: Seq[(BlockManagerId, Seq[(BlockId, Long)])]): Boolean={
+    readyStatuses.foreach( x =>
+      x._2.foreach(y =>
+        if (!delegatedStatuses.contains(x._1 + y._1.toString + y._2)){
+          return true
+        }
+      )
+    )
+    false
+  }
+
+  private def readyStatusesToIndex(readyStatuses: Seq[(BlockManagerId, Seq[(BlockId, Long)])]):Seq[String] = {
+    val res = new ArrayBuffer[String]()
+    readyStatuses.foreach(x =>{
+      x._2.foreach( y => {
+        res.append(x._1 + y._1.toString + y._2)
+      })
+    })
+    res
+  }
+
+  private def getIterator() = {
+    while (!newStatusesReady) {
+      logInfo("nothing to fetch sleep in partialIterator")
+      Thread.sleep(mapOutputFetchInterval)
+      updateStatuses()
+    }
+
+    for (index <- readyStatusesToIndex(readyStatuses) if !delegatedStatuses.contains(index)){
+      delegatedStatuses += index
+    }
+
+    logInfo("Delegating " + statuses.map(_._2.size).sum +
+      " blocks to a new iterator for reduce "  + " of shuffle " + shuffleId)
+
+    val blockFetcherItr = new ShuffleBlockFetcherIterator(
+      context,
+      blockManager.shuffleClient,
+      blockManager,
+      statuses,
+      SparkEnv.get.serializerManager.wrapStream,
+      // Note: we use getSizeAsMb when no suffix is provided for backwards compatibility
+      SparkEnv.get.conf.getSizeAsMb("spark.reducer.maxSizeInFlight", "48m") * 1024 * 1024,
+      SparkEnv.get.conf.getInt("spark.reducer.maxReqsInFlight", Int.MaxValue),
+      SparkEnv.get.conf.get(config.REDUCER_MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS),
+      SparkEnv.get.conf.get(config.MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM),
+      SparkEnv.get.conf.getBoolean("spark.shuffle.detectCorrupt", true))
+    blockFetcherItr
+  }
+
+  private[this] def initialize(){
+    iterator = getIterator()
+  }
+
+  override def hasNext: Boolean = {
+    // Firstly see if the delegated iterators have more blocks for us
+    if (iterator.hasNext) {
+      return true
+    }
+    // If we have blocks not delegated yet, try to delegate them to a new iterator
+    // and depend on the iterator to tell us if there are valid blocks.
+    while (delegatedStatuses.size < statuses.size) {
+      iterator = getIterator()
+      if(iterator == null) return false
+      if (iterator.hasNext) {
+        return true
+      }
+    }
+    false
+  }
+
+  override def next(): (BlockId, InputStream) = {
+    return iterator.next()
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, the downstream stage cannot start until all its depended stages all have finished. Therefore we propose to remove the barrier and pre-start the reduce stage once there're free cpu resource in some situations .This can get better resource utilization and improve the overall job performance.

 DAGScheduler:
	1: All parent stages finish 90%(default) ,could run the Child Stage
BlockStoreShuffleReader:
   1: when RSB is on : there are null in Mapoutput statuses
    2: we need read partital Status from the MapOutput statuses
PartialBlockFetcherIterator:
   1: Thread sleep if there is noting to read
   2: Build a Set to record FetchedStatuses
   3:get Partial( contains null) Statuses

 

## How was this patch tested?
Same sql in tpcds : set RSBthreshold = 95 %
RSB is on
![image](https://user-images.githubusercontent.com/37145547/70209646-ca3a9d80-176b-11ea-8be1-b8bab28743ee.png)
Time : 
433.133
--



RSB is off
![image](https://user-images.githubusercontent.com/37145547/70209656-d45c9c00-176b-11ea-96e3-599a46e43c75.png)

Time: 455.465

